### PR TITLE
V4 API and early aliases support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hopr-admin",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.1",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.11.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@fontsource/roboto": "^5.0.0",
-    "@hoprnet/hopr-sdk": "3.0.0-alpha.10",
+    "@hoprnet/hopr-sdk": "3.0.0-alpha.12",
     "@metamask/jazzicon": "^2.0.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hopr-admin",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.11.0",

--- a/src/components/ConnectNode/modal.tsx
+++ b/src/components/ConnectNode/modal.tsx
@@ -435,28 +435,23 @@ function ConnectNodeModal(props: ConnectNodeModalProps) {
           style={{ width: '100%' }}
           type={showPassword ? 'text' : 'password'}
           InputProps={{
-             endAdornment:
+            endAdornment: (
               <InputAdornment position="end">
                 <IconButton
-                  aria-label={
-                    showPassword ? 'hide the API token' : 'display the API token'
-                  }
-                  onClick={()=> setShowPassword((show) => !show)}
-                  onMouseDown={
-                    (event: React.MouseEvent<HTMLButtonElement>) => {
+                  aria-label={showPassword ? 'hide the API token' : 'display the API token'}
+                  onClick={() => setShowPassword((show) => !show)}
+                  onMouseDown={(event: React.MouseEvent<HTMLButtonElement>) => {
                     event.preventDefault();
-                    }
-                  }
-                  onMouseUp={
-                    (event: React.MouseEvent<HTMLButtonElement>) => {
+                  }}
+                  onMouseUp={(event: React.MouseEvent<HTMLButtonElement>) => {
                     event.preventDefault();
-                    }
-                  }
+                  }}
                   edge="end"
                 >
                   {showPassword ? <VisibilityOff /> : <Visibility />}
                 </IconButton>
               </InputAdornment>
+            ),
           }}
         />
         <SaveTokenContainer>

--- a/src/components/ConnectNode/modal.tsx
+++ b/src/components/ConnectNode/modal.tsx
@@ -19,10 +19,12 @@ import Button from '../../future-hopr-lib-components/Button';
 import StyledGrayButton from '../../future-hopr-lib-components/Button/gray';
 
 // MUI
-import { Tooltip, IconButton } from '@mui/material';
+import { Tooltip, IconButton, InputAdornment, Autocomplete } from '@mui/material';
 import { SelectChangeEvent } from '@mui/material/Select';
 import DeleteIcon from '@mui/icons-material/Delete';
 import CloseIcon from '@mui/icons-material/Close';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import Visibility from '@mui/icons-material/Visibility';
 
 type ParsedNode = {
   name: string;
@@ -141,6 +143,7 @@ function ConnectNodeModal(props: ConnectNodeModalProps) {
   const loginData = useAppSelector((store) => store.auth.loginData);
   const loginPending = useAppSelector((store) => store.auth.status.connecting);
   const [searchParams, set_searchParams] = useSearchParams();
+  const [showPassword, setShowPassword] = useState(false);
   const [localName, set_localName] = useState(loginData.localName ? loginData.localName : '');
   const [jazzIcon, set_jazzIcon] = useState(loginData.jazzIcon ? loginData.jazzIcon : null);
   const [apiEndpoint, set_apiEndpoint] = useState(loginData.apiEndpoint ? loginData.apiEndpoint : '');
@@ -430,6 +433,31 @@ function ConnectNodeModal(props: ConnectNodeModalProps) {
             set_apiToken(event.target.value);
           }}
           style={{ width: '100%' }}
+          type={showPassword ? 'text' : 'password'}
+          InputProps={{
+             endAdornment:
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label={
+                    showPassword ? 'hide the API token' : 'display the API token'
+                  }
+                  onClick={()=> setShowPassword((show) => !show)}
+                  onMouseDown={
+                    (event: React.MouseEvent<HTMLButtonElement>) => {
+                    event.preventDefault();
+                    }
+                  }
+                  onMouseUp={
+                    (event: React.MouseEvent<HTMLButtonElement>) => {
+                    event.preventDefault();
+                    }
+                  }
+                  edge="end"
+                >
+                  {showPassword ? <VisibilityOff /> : <Visibility />}
+                </IconButton>
+              </InputAdornment>
+          }}
         />
         <SaveTokenContainer>
           <Checkbox

--- a/src/components/Modal/node/AddAliasModal.tsx
+++ b/src/components/Modal/node/AddAliasModal.tsx
@@ -75,7 +75,7 @@ export const CreateAliasModal = (props: CreateAliasModalProps) => {
 
   const handleOpenModal = () => {
     (document.activeElement as HTMLInputElement).blur();
-    if(hasAlias) {
+    if (hasAlias) {
       set_alias(aliases[address]);
     }
     setOpenModal(true);
@@ -110,9 +110,9 @@ export const CreateAliasModal = (props: CreateAliasModalProps) => {
             props.tooltip
           ) : (
             <span>
-              { hasAlias ? 'EDIT' : 'ADD' }
+              {hasAlias ? 'EDIT' : 'ADD'}
               <br />
-              { hasAlias ? '' : 'new ' } alias
+              {hasAlias ? '' : 'new '} alias
             </span>
           )
         }
@@ -125,7 +125,7 @@ export const CreateAliasModal = (props: CreateAliasModalProps) => {
         disableScrollLock={true}
       >
         <TopBar>
-          <DialogTitle>{ hasAlias ? 'Edit' : 'Add' } Alias</DialogTitle>
+          <DialogTitle>{hasAlias ? 'Edit' : 'Add'} Alias</DialogTitle>
           <SIconButton
             aria-label="close modal"
             onClick={handleCloseModal}
@@ -175,7 +175,7 @@ export const CreateAliasModal = (props: CreateAliasModalProps) => {
               marginTop: '-6px',
             }}
           >
-            { hasAlias ? 'Edit' : 'Add' }
+            {hasAlias ? 'Edit' : 'Add'}
           </Button>
         </DialogActions>
       </SDialog>

--- a/src/components/Modal/node/AddAliasModal.tsx
+++ b/src/components/Modal/node/AddAliasModal.tsx
@@ -15,8 +15,7 @@ import AddAliasIcon from '../../../future-hopr-lib-components/Icons/AddAlias';
 import Button from '../../../future-hopr-lib-components/Button';
 
 type CreateAliasModalProps = {
-  handleRefresh: () => void;
-  peerId?: string;
+  address?: string;
   disabled?: boolean;
   tooltip?: JSX.Element | string;
 };
@@ -26,9 +25,9 @@ export const CreateAliasModal = (props: CreateAliasModalProps) => {
   const loginData = useAppSelector((store) => store.auth.loginData);
   const aliases = useAppSelector((store) => store.node.aliases);
   const [alias, set_alias] = useState<string>('');
-  const [peerId, set_peerId] = useState<string>(props.peerId ? props.peerId : '');
+  const [address, set_address] = useState<string>(props.address ? props.address : '');
   const [duplicateAlias, set_duplicateAlias] = useState(false);
-  const [duplicatePeerId, set_duplicatePeerId] = useState(false);
+  const [duplicateAddress, set_duplicateAddress] = useState(false);
   const [openModal, setOpenModal] = useState(false);
 
   const aliasesArr = aliases ? Object.keys(aliases) : [];
@@ -36,9 +35,9 @@ export const CreateAliasModal = (props: CreateAliasModalProps) => {
   const aliasIncludesASpace = alias.includes(' ');
   const canAddAlias = !(
     alias.length === 0 ||
-    peerId.length === 0 ||
+    address.length === 0 ||
     duplicateAlias ||
-    duplicatePeerId ||
+    duplicateAddress ||
     aliasIncludesASpace
   );
 
@@ -47,20 +46,20 @@ export const CreateAliasModal = (props: CreateAliasModalProps) => {
     return () => {
       window.removeEventListener('keydown', handleEnter as EventListener);
     };
-  }, [loginData, alias, peerId]);
+  }, [loginData, alias, address]);
 
-  const setPropPeerId = () => {
-    if (props.peerId) set_peerId(props.peerId);
+  const setPropAddress = () => {
+    if (props.address) set_address(props.address);
   };
-  useEffect(setPropPeerId, [props.peerId]);
+  useEffect(setPropAddress, [props.address]);
 
-  const handleChangePeerId = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChangeAddress = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (aliasPeerIdsArr.includes(event.target.value)) {
-      set_duplicatePeerId(true);
+      set_duplicateAddress(true);
     } else {
-      set_duplicatePeerId(false);
+      set_duplicateAddress(false);
     }
-    set_peerId(event.target.value);
+    set_address(event.target.value);
   };
 
   const handleChangeAlias = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -79,9 +78,9 @@ export const CreateAliasModal = (props: CreateAliasModalProps) => {
 
   const handleCloseModal = () => {
     set_duplicateAlias(false);
-    set_duplicatePeerId(false);
+    set_duplicateAddress(false);
     setOpenModal(false);
-    set_peerId(props.peerId ? props.peerId : '');
+    set_address(props.address ? props.address : '');
     set_alias('');
   };
 
@@ -178,15 +177,15 @@ export const CreateAliasModal = (props: CreateAliasModalProps) => {
         <SDialogContent>
           <TextField
             type="text"
-            name="peerId"
-            label="Peer ID"
-            placeholder="12D3Ko...Z3rz5F"
-            onChange={handleChangePeerId}
-            value={peerId}
-            error={duplicatePeerId}
-            helperText={duplicatePeerId ? 'This Peer Id already has an alias!' : ''}
+            name="address"
+            label="Node address"
+            placeholder="0x154a...d6D9E7f3"
+            onChange={handleChangeAddress}
+            value={address}
+            error={duplicateAddress}
+            helperText={duplicateAddress ? 'This Peer Id already has an alias!' : ''}
             style={{ minHeight: '79px' }}
-            autoFocus={peerId === ''}
+            autoFocus={address === ''}
           />
           <TextField
             type="text"
@@ -204,7 +203,7 @@ export const CreateAliasModal = (props: CreateAliasModalProps) => {
                 : ''
             }
             style={{ minHeight: '79px' }}
-            autoFocus={peerId !== ''}
+            autoFocus={address !== ''}
           />
         </SDialogContent>
         <DialogActions>

--- a/src/components/Modal/node/AddAliasModal.tsx
+++ b/src/components/Modal/node/AddAliasModal.tsx
@@ -2,18 +2,15 @@ import { useState, useEffect } from 'react';
 import { DialogTitle, TextField, DialogActions, Alert } from '@mui/material';
 import { SDialog, SDialogContent, SIconButton, TopBar } from '../../../future-hopr-lib-components/Modal/styled';
 import { useAppDispatch, useAppSelector } from '../../../store';
-import { nodeActions, nodeActionsAsync as actionsAsync } from '../../../store/slices/node';
-import { appActions } from '../../../store/slices/app';
+import { nodeActions } from '../../../store/slices/node';
 import CloseIcon from '@mui/icons-material/Close';
-import { sendNotification } from '../../../hooks/useWatcher/notifications';
 import { utils as hoprdUlils } from '@hoprnet/hopr-sdk';
-const { sdkApiError } = hoprdUlils;
+import { isAddress } from 'viem';
 
 // HOPR Components
 import IconButton from '../../../future-hopr-lib-components/Button/IconButton';
 import AddAliasIcon from '../../../future-hopr-lib-components/Icons/AddAlias';
 import Button from '../../../future-hopr-lib-components/Button';
-import { add } from 'lodash';
 
 type CreateAliasModalProps = {
   address?: string;
@@ -28,6 +25,7 @@ export const CreateAliasModal = (props: CreateAliasModalProps) => {
   const nodeAddress = useAppSelector((store) => store.node.addresses.data.native);
   const [alias, set_alias] = useState<string>('');
   const [address, set_address] = useState<string>(props.address ? props.address : '');
+  const isAddressValid = isAddress(address);
   const [duplicateAlias, set_duplicateAlias] = useState(false);
   const [duplicateAddress, set_duplicateAddress] = useState(false);
   const [openModal, setOpenModal] = useState(false);
@@ -41,7 +39,8 @@ export const CreateAliasModal = (props: CreateAliasModalProps) => {
     address.length === 0 ||
     duplicateAlias ||
     duplicateAddress ||
-    aliasIncludesASpace
+    aliasIncludesASpace ||
+    !isAddressValid
   );
 
   useEffect(() => {
@@ -126,7 +125,7 @@ export const CreateAliasModal = (props: CreateAliasModalProps) => {
         disableScrollLock={true}
       >
         <TopBar>
-          <DialogTitle>Add Alias</DialogTitle>
+          <DialogTitle>{ hasAlias ? 'Edit' : 'Add' } Alias</DialogTitle>
           <SIconButton
             aria-label="close modal"
             onClick={handleCloseModal}
@@ -176,7 +175,7 @@ export const CreateAliasModal = (props: CreateAliasModalProps) => {
               marginTop: '-6px',
             }}
           >
-            Add
+            { hasAlias ? 'Edit' : 'Add' }
           </Button>
         </DialogActions>
       </SDialog>

--- a/src/components/Modal/node/OpenChannelModal.tsx
+++ b/src/components/Modal/node/OpenChannelModal.tsx
@@ -51,7 +51,7 @@ export const OpenChannelModal = ({ ...props }: OpenChannelModalProps) => {
   const [peerAddress, set_peerAddress] = useState(props.peerAddress ? props.peerAddress : '');
   const canOpen = !(!amount || parseFloat(amount) <= 0 || !peerAddress);
   const peers = useAppSelector((store) => store.node.peers.data);
-  const myAddress = useAppSelector((store) => store.node.addresses.data.native);
+  const myAddress = useAppSelector((store) => store.node.addresses.data.native || '');
   const sortedAliases = useAppSelector((store) => store.node.links.sortedAliases);
   const aliasToNodeAddress = useAppSelector((store) => store.node.links.aliasToNodeAddress);
   const sortedAnnouncedPeers = useAppSelector((store) => store.node.peers.parsed.announcedSorted);
@@ -59,7 +59,9 @@ export const OpenChannelModal = ({ ...props }: OpenChannelModalProps) => {
   const addressBook = [
     myAddress,
     ...sortedAliases.map((alias) => aliasToNodeAddress[alias]),
-    ...sortedAnnouncedPeers.filter(nodeAddress => nodeAddress !== myAddress && !nodeAddressesWithAliases.includes(nodeAddress))
+    ...sortedAnnouncedPeers.filter(
+      (nodeAddress) => nodeAddress !== myAddress && !nodeAddressesWithAliases.includes(nodeAddress),
+    ),
   ];
 
   useEffect(() => {
@@ -159,6 +161,7 @@ export const OpenChannelModal = ({ ...props }: OpenChannelModalProps) => {
         open={openChannelModal}
         onClose={handleCloseModal}
         disableScrollLock={true}
+        maxWidth={'800px'}
       >
         <TopBar>
           <DialogTitle>Open Outgoing Channel</DialogTitle>

--- a/src/components/Modal/node/OpenChannelModal.tsx
+++ b/src/components/Modal/node/OpenChannelModal.tsx
@@ -29,7 +29,6 @@ export const OpenChannelModal = ({ ...props }: OpenChannelModalProps) => {
   const loginData = useAppSelector((store) => store.auth.loginData);
   const outgoingOpening = useAppSelector((store) => store.node.channels.parsed.outgoingOpening);
   const aliases = useAppSelector((store) => store.node.aliases);
-  const peerIdToAliasLink = useAppSelector((store) => store.node.links.peerIdToAlias);
   const channelIsBeingOpened = props.peerAddress ? !!outgoingOpening[props.peerAddress] : false;
   const [openChannelModal, set_openChannelModal] = useState(false);
   const [amount, set_amount] = useState('');
@@ -43,9 +42,9 @@ export const OpenChannelModal = ({ ...props }: OpenChannelModalProps) => {
     };
   }, [openChannelModal, loginData, amount, peerAddress]);
 
-  const getAliasByPeerId = (peerId: string): string => {
-    if (aliases && peerId && peerIdToAliasLink[peerId]) return `${peerIdToAliasLink[peerId]} (${peerId})`;
-    return peerId;
+  const getAliasByAddress = (address: string): string => {
+    if (aliases && address && aliases[address]) return `${aliases[address]} (${address})`;
+    return address;
   };
 
   const handleOpenChannelDialog = () => {

--- a/src/components/Modal/node/OpenMultipleChannelsModal.tsx
+++ b/src/components/Modal/node/OpenMultipleChannelsModal.tsx
@@ -224,7 +224,7 @@ export const OpenMultipleChannelsModal = () => {
           <STextField
             label="Peer Ids"
             type="string"
-            placeholder="0x154a...d6D9E7f3,12D3Ko...wxd4zv,12D3Ko...zF8c7u"
+            placeholder="0x154a...d6D9E7f3,0x10a...54Ee2662,0x207...45Ef2613"
             value={peerIds.join(',\n')}
             multiline
             rows={8}

--- a/src/components/Modal/node/OpenMultipleChannelsModal.tsx
+++ b/src/components/Modal/node/OpenMultipleChannelsModal.tsx
@@ -224,7 +224,7 @@ export const OpenMultipleChannelsModal = () => {
           <STextField
             label="Peer Ids"
             type="string"
-            placeholder="12D3Ko...Z3rz5F,12D3Ko...wxd4zv,12D3Ko...zF8c7u"
+            placeholder="0x154a...d6D9E7f3,12D3Ko...wxd4zv,12D3Ko...zF8c7u"
             value={peerIds.join(',\n')}
             multiline
             rows={8}

--- a/src/components/Modal/node/OpenSessionModal.tsx
+++ b/src/components/Modal/node/OpenSessionModal.tsx
@@ -134,12 +134,14 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
   const myAddress = useAppSelector((store) => store.node.addresses.data.native || '');
   const sortedAliases = useAppSelector((store) => store.node.links.sortedAliases);
   const aliasToNodeAddress = useAppSelector((store) => store.node.links.aliasToNodeAddress);
-  const sortedConnectedPeers = useAppSelector((store) => store.node.peers.parsed.connectedSorted);
+  const sortedAnnouncedPeers = useAppSelector((store) => store.node.peers.parsed.announcedSorted);
   const nodeAddressesWithAliases = useAppSelector((store) => store.node.links.nodeAddressesWithAliases);
   const addressBook = [
     myAddress,
     ...sortedAliases.map((alias) => aliasToNodeAddress[alias]),
-    ...sortedConnectedPeers.filter(nodeAddress => nodeAddress !== myAddress && !nodeAddressesWithAliases.includes(nodeAddress))
+    ...sortedAnnouncedPeers.filter(
+      (nodeAddress) => nodeAddress !== myAddress && !nodeAddressesWithAliases.includes(nodeAddress),
+    ),
   ];
 
   // Errors

--- a/src/components/Modal/node/OpenSessionModal.tsx
+++ b/src/components/Modal/node/OpenSessionModal.tsx
@@ -110,19 +110,19 @@ const Splitscreen = styled.div`
 function sortAddresses(
   peers: GetPeersResponseType | null,
   myAddress: string | null,
-  peerIdToAliasLink: {
+  aliases: {
     [peerId: string]: string;
   },
 ): string[] {
   if (!peers || !myAddress) return [];
   const connectedPeers = peers.connected;
-  const peerIdsWithAliases = Object.keys(peerIdToAliasLink).sort((a, b) =>
-    peerIdToAliasLink[a] < peerIdToAliasLink[b] ? -1 : 1,
+  const peerIdsWithAliases = Object.values(aliases).sort((a, b) =>
+    aliases[a] < aliases[b] ? -1 : 1,
   );
   if (peerIdsWithAliases.length === 0) return [myAddress, ...connectedPeers.map((peer) => peer.address).sort()];
   const peerIdsWithAliasesWithoutMyAddress = peerIdsWithAliases.filter((peerId) => peerId !== myAddress);
   const connectedPeersWithoutAliases = connectedPeers
-    .filter((peer) => !peerIdToAliasLink[peer.address])
+    .filter((peer) => !aliases[peer.address])
     .map((peer) => peer.address)
     .sort();
   return [myAddress, ...peerIdsWithAliasesWithoutMyAddress, ...connectedPeersWithoutAliases];
@@ -144,10 +144,9 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
   const [openModal, set_openModal] = useState<boolean>(false);
   const loginData = useAppSelector((store) => store.auth.loginData);
   const aliases = useAppSelector((store) => store.node.aliases);
-  const peerIdToAliasLink = useAppSelector((store) => store.node.links.peerIdToAlias);
   const peers = useAppSelector((store) => store.node.peers.data);
   const myAddress = useAppSelector((store) => store.node.addresses.data.native);
-  const sendMessageAddressBook = sortAddresses(peers, myAddress, peerIdToAliasLink);
+  const sendMessageAddressBook = sortAddresses(peers, myAddress, aliases);
   const [destination, set_destination] = useState<string | null>(props.destination ? props.destination : null);
   const [listenHost, set_listenHost] = useState<string>('');
   const [sessionTarget, set_sessionTarget] = useState<string>('');
@@ -414,8 +413,8 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
               set_destination(newValue);
             }}
             options={sendMessageAddressBook}
-            getOptionLabel={(peerId) =>
-              peerIdToAliasLink[peerId] ? `${peerIdToAliasLink[peerId]} (${peerId})` : peerId
+            getOptionLabel={(address) =>
+              aliases[address] ? `${aliases[address]} (${address})` : address
             }
             autoSelect
             renderInput={(params) => (
@@ -566,8 +565,8 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
                       });
                     }}
                     options={sendMessageAddressBook}
-                    getOptionLabel={(peerId) =>
-                      peerIdToAliasLink[peerId] ? `${peerIdToAliasLink[peerId]} (${peerId})` : peerId
+                    getOptionLabel={(address) =>
+                      aliases[address] ? `${aliases[address]} (${address})` : address
                     }
                     autoSelect
                     renderInput={(params) => (
@@ -653,8 +652,8 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
                       });
                     }}
                     options={sendMessageAddressBook}
-                    getOptionLabel={(peerId) =>
-                      peerIdToAliasLink[peerId] ? `${peerIdToAliasLink[peerId]} (${peerId})` : peerId
+                    getOptionLabel={(address) =>
+                      aliases[address] ? `${aliases[address]} (${address})` : address
                     }
                     autoSelect
                     renderInput={(params) => (

--- a/src/components/Modal/node/OpenSessionModal.tsx
+++ b/src/components/Modal/node/OpenSessionModal.tsx
@@ -115,15 +115,20 @@ function sortAddresses(
   },
 ): string[] {
   if (!peers || !myAddress) return [];
-  const connectedPeers = peers.connected;
-  const peerIdsWithAliases = Object.values(aliases).sort((a, b) => (aliases[a] < aliases[b] ? -1 : 1));
-  if (peerIdsWithAliases.length === 0) return [myAddress, ...connectedPeers.map((peer) => peer.address).sort()];
-  const peerIdsWithAliasesWithoutMyAddress = peerIdsWithAliases.filter((peerId) => peerId !== myAddress);
-  const connectedPeersWithoutAliases = connectedPeers
-    .filter((peer) => !aliases[peer.address])
+  const filteredPeers = peers.connected
+    .filter((peer) => peer.address !== myAddress)
     .map((peer) => peer.address)
     .sort();
-  return [myAddress, ...peerIdsWithAliasesWithoutMyAddress, ...connectedPeersWithoutAliases];
+  const sortedAliases = Object.values(aliases).sort((a, b) => (aliases[a] < aliases[b] ? -1 : 1));
+  if (sortedAliases.length === 0) return [myAddress, ...filteredPeers];
+  // TODO: put that directly in the store
+  const aliasToNodeAddressMap = {} as Record<string, string>;
+  Object.keys(aliases).forEach((nodeAddress) => {
+    aliasToNodeAddressMap[aliases[nodeAddress]] = nodeAddress;
+  });
+  const sortedPeersWithAliases = sortedAliases.map((alias) => aliasToNodeAddressMap[alias]);
+  const peersWithoutAliases = filteredPeers.filter((nodeAddress) => !aliases[nodeAddress]);
+  return [myAddress, ...sortedPeersWithAliases, ...peersWithoutAliases];
 }
 
 export const OpenSessionModal = (props: OpenSessionModalProps) => {

--- a/src/components/Modal/node/OpenSessionModal.tsx
+++ b/src/components/Modal/node/OpenSessionModal.tsx
@@ -116,9 +116,7 @@ function sortAddresses(
 ): string[] {
   if (!peers || !myAddress) return [];
   const connectedPeers = peers.connected;
-  const peerIdsWithAliases = Object.values(aliases).sort((a, b) =>
-    aliases[a] < aliases[b] ? -1 : 1,
-  );
+  const peerIdsWithAliases = Object.values(aliases).sort((a, b) => (aliases[a] < aliases[b] ? -1 : 1));
   if (peerIdsWithAliases.length === 0) return [myAddress, ...connectedPeers.map((peer) => peer.address).sort()];
   const peerIdsWithAliasesWithoutMyAddress = peerIdsWithAliases.filter((peerId) => peerId !== myAddress);
   const connectedPeersWithoutAliases = connectedPeers
@@ -413,9 +411,7 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
               set_destination(newValue);
             }}
             options={sendMessageAddressBook}
-            getOptionLabel={(address) =>
-              aliases[address] ? `${aliases[address]} (${address})` : address
-            }
+            getOptionLabel={(address) => (aliases[address] ? `${aliases[address]} (${address})` : address)}
             autoSelect
             renderInput={(params) => (
               <TextField
@@ -565,9 +561,7 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
                       });
                     }}
                     options={sendMessageAddressBook}
-                    getOptionLabel={(address) =>
-                      aliases[address] ? `${aliases[address]} (${address})` : address
-                    }
+                    getOptionLabel={(address) => (aliases[address] ? `${aliases[address]} (${address})` : address)}
                     autoSelect
                     renderInput={(params) => (
                       <TextField
@@ -652,9 +646,7 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
                       });
                     }}
                     options={sendMessageAddressBook}
-                    getOptionLabel={(address) =>
-                      aliases[address] ? `${aliases[address]} (${address})` : address
-                    }
+                    getOptionLabel={(address) => (aliases[address] ? `${aliases[address]} (${address})` : address)}
                     autoSelect
                     renderInput={(params) => (
                       <TextField

--- a/src/components/Modal/node/PingModal.tsx
+++ b/src/components/Modal/node/PingModal.tsx
@@ -23,7 +23,6 @@ export const PingModal = (props: PingModalProps) => {
   const dispatch = useAppDispatch();
   const loginData = useAppSelector((selector) => selector.auth.loginData);
   const aliases = useAppSelector((store) => store.node.aliases);
-  const peerIdToAliasLink = useAppSelector((store) => store.node.links.peerIdToAlias);
   const [address, set_address] = useState<string>(props.address ? props.address : '');
   const [openModal, set_OpenModal] = useState(false);
   const [disableButton, set_disableButton] = useState(false);
@@ -36,8 +35,8 @@ export const PingModal = (props: PingModalProps) => {
     };
   }, [loginData, address]);
 
-  const getAliasByPeerId = (address: string): string => {
-    if (aliases && address && peerIdToAliasLink[address]) return `${peerIdToAliasLink[address]} (${address})`;
+  const getAliasByAddress = (address: string): string => {
+    if (aliases && address && aliases[address]) return `${aliases[address]} (${address})`;
     return address;
   };
 
@@ -73,7 +72,7 @@ export const PingModal = (props: PingModalProps) => {
       )
         .unwrap()
         .then((resp: PingPeerResponseType) => {
-          const msg = `Ping of ${getAliasByPeerId(address)} succeeded with latency of ${resp.latency}ms`;
+          const msg = `Ping of ${getAliasByAddress(address)} succeeded with latency of ${resp.latency}ms`;
           console.log(msg, resp);
           sendNotification({
             notificationPayload: {
@@ -92,7 +91,7 @@ export const PingModal = (props: PingModalProps) => {
           ).unwrap();
           if (!isCurrentApiEndpointTheSame) return;
 
-          let errMsg = `Ping of ${getAliasByPeerId(address)} failed`;
+          let errMsg = `Ping of ${getAliasByAddress(address)} failed`;
           if (e instanceof sdkApiError && e.hoprdErrorPayload?.status)
             errMsg = errMsg + `.\n${e.hoprdErrorPayload.status}`;
           if (e instanceof sdkApiError && e.hoprdErrorPayload?.error)

--- a/src/components/Modal/node/SendMessageModal.tsx_
+++ b/src/components/Modal/node/SendMessageModal.tsx_
@@ -385,7 +385,7 @@ export const SendMessageModal = (props: SendMessageModalProps) => {
           {sendMode === 'path' && (
             <TextField
               label="Path (PeerIds or Aliases)"
-              placeholder={'12D3Ko...Z3rz5F,\n12D3Ko...wxd4zv,\nAlan,\n12D3Ko...zF8c7u'}
+              placeholder={'0x154a...d6D9E7f3,\n12D3Ko...wxd4zv,\nAlan,\n12D3Ko...zF8c7u'}
               value={path}
               onChange={handlePath}
               onKeyDown={handlePathKeyDown}

--- a/src/future-hopr-lib-components/PeerInfo/index.tsx
+++ b/src/future-hopr-lib-components/PeerInfo/index.tsx
@@ -12,10 +12,7 @@ import CopyIcon from '@mui/icons-material/ContentCopy';
 import LaunchIcon from '@mui/icons-material/Launch';
 
 interface Props {
-  peerId?: string;
   nodeAddress?: string;
-  shortenPeerId?: boolean;
-  shortenPeerIdIfAliasPresent?: boolean;
 }
 
 const Container = styled.div`
@@ -28,22 +25,12 @@ const Container = styled.div`
 `;
 
 const PeersInfo: React.FC<Props> = (props) => {
-  const { peerId, nodeAddress, ...rest } = props;
+  const { nodeAddress, ...rest } = props;
   const aliases = useAppSelector((store) => store.node.aliases);
-  const peerIdToAliasLink = useAppSelector((store) => store.node.links.peerIdToAlias);
 
-  const getAliasByPeerId = (peerId: string): string | JSX.Element => {
-    const aliasPresent = aliases && peerId && peerIdToAliasLink[peerId];
-    const shortPeerId = peerId && `${peerId.substring(0, 6)}...${peerId.substring(peerId.length - 8, peerId.length)}`;
-    const displayPeerId =
-      props.shortenPeerId || (props.shortenPeerIdIfAliasPresent && aliasPresent) ? shortPeerId : peerId;
-    if (aliasPresent)
-      return (
-        <>
-          <strong>{aliasPresent}</strong> ({displayPeerId})
-        </>
-      );
-    return displayPeerId;
+  const getAliasByAddress = (address: string): string => {
+    if (aliases && address && aliases[address]) return `${aliases[address]} (${address})`;
+    return address;
   };
 
   const noCopyPaste = !(
@@ -62,16 +49,7 @@ const PeersInfo: React.FC<Props> = (props) => {
         data-src={nodeAddress}
       />
       <div>
-        <span>{peerId && getAliasByPeerId(peerId)}</span>{' '}
-        <SmallActionButton
-          onClick={() => navigator.clipboard.writeText(peerId as string)}
-          disabled={noCopyPaste}
-          tooltip={noCopyPaste ? 'Clipboard not supported on HTTP' : 'Copy Peer Id'}
-        >
-          <CopyIcon />
-        </SmallActionButton>
-        <br />
-        <span>{nodeAddress}</span>{' '}
+        <span>{nodeAddress && getAliasByAddress(nodeAddress)}</span>{' '}
         <SmallActionButton
           onClick={() => navigator.clipboard.writeText(nodeAddress as string)}
           disabled={noCopyPaste}

--- a/src/future-hopr-lib-components/Select/index.tsx
+++ b/src/future-hopr-lib-components/Select/index.tsx
@@ -57,7 +57,6 @@ type Props = SelectMuiProps & {
 };
 
 const Select: React.FC<Props> = (props) => {
-  console.log('props.values', props.values);
   return (
     <SFormControl
       style={props.style}

--- a/src/hooks/useWatcher/index.ts
+++ b/src/hooks/useWatcher/index.ts
@@ -7,6 +7,7 @@ import { observeNodeInfo } from './info';
 import { sendNotification } from '../../hooks/useWatcher/notifications';
 import { nodeActions, nodeActionsAsync } from '../../store/slices/node';
 import { checkHowChannelsHaveChanged } from './channels';
+import { isAddress } from 'viem';
 
 export const useWatcher = ({ intervalDuration = 60_000 }: { intervalDuration?: number }) => {
   const dispatch = useAppDispatch();
@@ -16,6 +17,7 @@ export const useWatcher = ({ intervalDuration = 60_000 }: { intervalDuration?: n
   const channelsParsed = useAppSelector((store) => store.node.channels.parsed);
   const firstChannelsCallWasSuccesfull = useAppSelector((store) => !!store.node.channels.data);
   const connected = useAppSelector((store) => store.auth.status.connected);
+  const nodeAddress = useAppSelector((store) => store.node.addresses.data.native);
 
   // flags to activate notifications
   const activeChannels = useAppSelector((store) => store.app.configuration.notifications.channels);
@@ -224,5 +226,12 @@ export const useWatcher = ({ intervalDuration = 60_000 }: { intervalDuration?: n
     channelsParsed,
     prevOutgoingChannels,
     prevIncomingChannels,
+  ]);
+
+  // Aliases
+  useEffect(() => {
+    dispatch(nodeActions.loadAliasesFromLocalStorage(nodeAddress));
+  }, [
+    nodeAddress
   ]);
 };

--- a/src/hooks/useWatcher/index.ts
+++ b/src/hooks/useWatcher/index.ts
@@ -231,7 +231,5 @@ export const useWatcher = ({ intervalDuration = 60_000 }: { intervalDuration?: n
   // Aliases
   useEffect(() => {
     dispatch(nodeActions.loadAliasesFromLocalStorage(nodeAddress));
-  }, [
-    nodeAddress
-  ]);
+  }, [nodeAddress]);
 };

--- a/src/pages/node/aliases.tsx
+++ b/src/pages/node/aliases.tsx
@@ -89,9 +89,7 @@ function AliasesPage() {
             disabled={nodeAddress === myNodeAddress}
             tooltip={nodeAddress === myNodeAddress ? `You can't ping yourself` : undefined}
           />
-          <CreateAliasModal
-            address={nodeAddress}
-          />
+          <CreateAliasModal address={nodeAddress} />
           {nodeAddress && nodeAddressToOutgoingChannelLink[nodeAddress] ? (
             <FundChannelModal channelId={nodeAddressToOutgoingChannelLink[nodeAddress]} />
           ) : (

--- a/src/pages/node/aliases.tsx
+++ b/src/pages/node/aliases.tsx
@@ -89,6 +89,9 @@ function AliasesPage() {
             disabled={nodeAddress === myNodeAddress}
             tooltip={nodeAddress === myNodeAddress ? `You can't ping yourself` : undefined}
           />
+          <CreateAliasModal
+            address={nodeAddress}
+          />
           {nodeAddress && nodeAddressToOutgoingChannelLink[nodeAddress] ? (
             <FundChannelModal channelId={nodeAddressToOutgoingChannelLink[nodeAddress]} />
           ) : (

--- a/src/pages/node/aliases.tsx
+++ b/src/pages/node/aliases.tsx
@@ -53,8 +53,8 @@ function AliasesPage() {
         nodeActions.setAlias({
           nodeAddress: data.address || data.nodeAddress,
           alias: data.alias,
-        })
-      )
+        }),
+      );
     }
   };
 
@@ -79,11 +79,7 @@ function AliasesPage() {
       id: nodeAddress,
       key: index.toString(),
       alias,
-      node: (
-        <PeersInfo
-          nodeAddress={nodeAddress}
-        />
-      ),
+      node: <PeersInfo nodeAddress={nodeAddress} />,
       lastSeen: <span style={{ whiteSpace: 'break-spaces' }}>{myNodeAddress === nodeAddress ? '-' : lastSeen}</span>,
       nodeAddress: nodeAddress,
       actions: (
@@ -164,7 +160,7 @@ function AliasesPage() {
     >
       <SubpageTitle
         title={`ALIASES (${parsedTableData.length})`}
-      //  refreshFunction={handleRefresh}
+        //  refreshFunction={handleRefresh}
         actions={
           <>
             <CreateAliasModal />
@@ -235,9 +231,7 @@ function CreateAliasForm() {
       />
       <button
         disabled={form.alias.length === 0 || form.peerId.length === 0}
-        onClick={() => {
-
-        }}
+        onClick={() => {}}
       >
         add
       </button>

--- a/src/pages/node/aliases.tsx
+++ b/src/pages/node/aliases.tsx
@@ -31,44 +31,30 @@ function AliasesPage() {
   const peersObject = useAppSelector((store) => store.node.peers.parsed.connected);
   const myNodeAddress = useAppSelector((store) => store.node.addresses.data.native);
   const loginData = useAppSelector((store) => store.auth.loginData);
-  const nodeAddressesWithAliases = Object.keys(aliases);
   const nodeAddressToOutgoingChannelLink = useAppSelector((store) => store.node.links.nodeAddressToOutgoingChannel);
-  const [importSuccess, set_importSuccess] = useState(false);
-  const [deleteSuccess, set_deleteSuccess] = useState(false);
-  const [importErrors, set_importErrors] = useState<
-    { status: string | undefined; error: string | undefined; alias: string }[]
-  >([]);
-  const [deleteErrors, set_deleteErrors] = useState<
-    { status: string | undefined; error: string | undefined; alias: string }[]
-  >([]);
-
-  useEffect(() => {
-
-  }, [loginData]);
-
-  const handleRefresh = () => {
-
-  };
 
   const handleExport = () => {
     if (aliases) {
       exportToCsv(
-        Object.keys(aliases).map((alias) => ({
-          alias: alias,
-          peerId: aliases[alias],
+        Object.keys(aliases).map((address) => ({
+          address,
+          alias: aliases[address],
         })),
-        'aliases.csv',
+        `aliases-${myNodeAddress}.csv`,
       );
     }
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleCSVUpload = async (parsedData: any[]) => {
-    if (!loginData.apiEndpoint) return;
+    if (!myNodeAddress) return;
     for (const data of parsedData) {
-      if (data.alias && data.peerId) {
-
-      }
+      dispatch(
+        nodeActions.setAlias({
+          nodeAddress: data.address || data.nodeAddress,
+          alias: data.alias,
+        })
+      )
     }
   };
 
@@ -178,7 +164,7 @@ function AliasesPage() {
     >
       <SubpageTitle
         title={`ALIASES (${parsedTableData.length})`}
-        refreshFunction={handleRefresh}
+      //  refreshFunction={handleRefresh}
         actions={
           <>
             <CreateAliasModal />

--- a/src/pages/node/channelsIncoming.tsx
+++ b/src/pages/node/channelsIncoming.tsx
@@ -228,11 +228,7 @@ function ChannelsPage() {
       return {
         id: (index + 1).toString(),
         key: id,
-        node: (
-          <PeersInfo
-            nodeAddress={peerAddress}
-          />
-        ),
+        node: <PeersInfo nodeAddress={peerAddress} />,
         peerAddress: getAliasByPeerAddress(peerAddress as string),
         status: channelsIncomingObject[id].status,
         funds: `${channelsIncomingObject[id].balance} ${HOPR_TOKEN_USED}`,
@@ -254,9 +250,7 @@ function ChannelsPage() {
                 ) : undefined
               }
             />
-            <CreateAliasModal
-              address={peerAddress}
-            />
+            <CreateAliasModal address={peerAddress} />
             {outgoingChannelOpened ? (
               <FundChannelModal channelId={id} />
             ) : (

--- a/src/pages/node/channelsIncoming.tsx
+++ b/src/pages/node/channelsIncoming.tsx
@@ -41,7 +41,6 @@ function ChannelsPage() {
   const nodeAddressToPeerIdLink = useAppSelector((store) => store.node.links.nodeAddressToPeerId);
   const nodeAddressToOutgoingChannelLink = useAppSelector((store) => store.node.links.nodeAddressToOutgoingChannel);
   const tickets = useAppSelector((store) => store.node.metricsParsed.tickets.incoming);
-  const peerIdToAliasLink = useAppSelector((store) => store.node.links.peerIdToAlias);
   const tabLabel = 'incoming';
   const channelsData = channels?.incoming;
 
@@ -67,10 +66,9 @@ function ChannelsPage() {
     return peerId!;
   };
 
-  const getAliasByPeerAddress = (nodeAddress: string): string => {
-    const peerId = getPeerIdFromPeerAddress(nodeAddress);
-    if (aliases && peerId && peerIdToAliasLink[peerId]) return `${peerIdToAliasLink[peerId]} (${nodeAddress})`;
-    return nodeAddress;
+  const getAliasByPeerAddress = (address: string): string => {
+    if (aliases && address && aliases[address]) return `${aliases[address]} (${address})`;
+    return address;
   };
 
   const handleExport = () => {
@@ -102,12 +100,6 @@ function ChannelsPage() {
       name: 'Node Address',
       search: true,
       copy: true,
-      hidden: true,
-    },
-    {
-      key: 'peerId',
-      name: 'Peer Id',
-      search: true,
       hidden: true,
     },
     {
@@ -238,9 +230,7 @@ function ChannelsPage() {
         key: id,
         node: (
           <PeersInfo
-            peerId={peerId}
             nodeAddress={peerAddress}
-            shortenPeerIdIfAliasPresent
           />
         ),
         peerAddress: getAliasByPeerAddress(peerAddress as string),
@@ -264,22 +254,9 @@ function ChannelsPage() {
                 ) : undefined
               }
             />
-            {/* <CreateAliasModal
-              handleRefresh={handleRefresh}
-              peerId={peerId}
-              disabled={!peerId}
-              tooltip={
-                !peerId ? (
-                  <span>
-                    DISABLED
-                    <br />
-                    Unable to find
-                    <br />
-                    peerId
-                  </span>
-                ) : undefined
-              }
-            /> */}
+            <CreateAliasModal
+              address={peerAddress}
+            />
             {outgoingChannelOpened ? (
               <FundChannelModal channelId={id} />
             ) : (

--- a/src/pages/node/channelsIncoming.tsx
+++ b/src/pages/node/channelsIncoming.tsx
@@ -38,7 +38,6 @@ function ChannelsPage() {
   const aliases = useAppSelector((store) => store.node.aliases);
   const currentApiEndpoint = useAppSelector((store) => store.node.apiEndpoint);
   const loginData = useAppSelector((store) => store.auth.loginData);
-  const nodeAddressToPeerIdLink = useAppSelector((store) => store.node.links.nodeAddressToPeerId);
   const nodeAddressToOutgoingChannelLink = useAppSelector((store) => store.node.links.nodeAddressToOutgoingChannel);
   const tickets = useAppSelector((store) => store.node.metricsParsed.tickets.incoming);
   const tabLabel = 'incoming';
@@ -59,11 +58,6 @@ function ChannelsPage() {
         apiToken: loginData.apiToken ? loginData.apiToken : '',
       }),
     );
-  };
-
-  const getPeerIdFromPeerAddress = (nodeAddress: string): string => {
-    const peerId = nodeAddressToPeerIdLink[nodeAddress];
-    return peerId!;
   };
 
   const getAliasByPeerAddress = (address: string): string => {
@@ -216,7 +210,6 @@ function ChannelsPage() {
         channelsIncomingObject[id].peerAddress &&
         !!nodeAddressToOutgoingChannelLink[channelsIncomingObject[id].peerAddress as string]
       );
-      const peerId = getPeerIdFromPeerAddress(channelsIncomingObject[id].peerAddress as string);
       const peerAddress = channelsIncomingObject[id].peerAddress;
 
       const totalTicketsPerChannel = `${formatEther(

--- a/src/pages/node/channelsOutgoing.tsx
+++ b/src/pages/node/channelsOutgoing.tsx
@@ -39,7 +39,6 @@ function ChannelsPage() {
   const loginData = useAppSelector((store) => store.auth.loginData);
   const currentApiEndpoint = useAppSelector((store) => store.node.apiEndpoint);
   const nodeAddressToPeerIdLink = useAppSelector((store) => store.node.links.nodeAddressToPeerId);
-  const peerIdToAliasLink = useAppSelector((store) => store.node.links.peerIdToAlias);
   const tabLabel = 'outgoing';
   const channelsData = channels?.outgoing;
 
@@ -64,10 +63,9 @@ function ChannelsPage() {
     return peerId!;
   };
 
-  const getAliasByPeerAddress = (nodeAddress: string): string => {
-    const peerId = getPeerIdFromPeerAddress(nodeAddress);
-    if (aliases && peerId && peerIdToAliasLink[peerId]) return `${peerIdToAliasLink[peerId]} (${nodeAddress})`;
-    return nodeAddress;
+  const getAliasByPeerAddress = (address: string): string => {
+    if (aliases && address && aliases[address]) return `${aliases[address]} (${address})`;
+    return address;
   };
 
   const handleExport = () => {
@@ -222,9 +220,7 @@ function ChannelsPage() {
         key: id,
         node: (
           <PeersInfo
-            peerId={''}
             nodeAddress={peerAddress}
-            shortenPeerIdIfAliasPresent
           />
         ),
         peerAddress: getAliasByPeerAddress(peerAddress as string),

--- a/src/pages/node/channelsOutgoing.tsx
+++ b/src/pages/node/channelsOutgoing.tsx
@@ -218,11 +218,7 @@ function ChannelsPage() {
       return {
         id: (index + 1).toString(),
         key: id,
-        node: (
-          <PeersInfo
-            nodeAddress={peerAddress}
-          />
-        ),
+        node: <PeersInfo nodeAddress={peerAddress} />,
         peerAddress: getAliasByPeerAddress(peerAddress as string),
         status: channelsOutgoingObject[id].status as string,
         funds: `${channelsOutgoingObject[id].balance} ${HOPR_TOKEN_USED}`,

--- a/src/pages/node/channelsOutgoing.tsx
+++ b/src/pages/node/channelsOutgoing.tsx
@@ -38,7 +38,6 @@ function ChannelsPage() {
   const aliases = useAppSelector((store) => store.node.aliases);
   const loginData = useAppSelector((store) => store.auth.loginData);
   const currentApiEndpoint = useAppSelector((store) => store.node.apiEndpoint);
-  const nodeAddressToPeerIdLink = useAppSelector((store) => store.node.links.nodeAddressToPeerId);
   const tabLabel = 'outgoing';
   const channelsData = channels?.outgoing;
 
@@ -56,11 +55,6 @@ function ChannelsPage() {
         apiToken: loginData.apiToken ? loginData.apiToken : '',
       }),
     );
-  };
-
-  const getPeerIdFromPeerAddress = (nodeAddress: string): string => {
-    const peerId = nodeAddressToPeerIdLink[nodeAddress];
-    return peerId!;
   };
 
   const getAliasByPeerAddress = (address: string): string => {

--- a/src/pages/node/peers.tsx
+++ b/src/pages/node/peers.tsx
@@ -104,9 +104,7 @@ function PeersPage() {
     },
   ];
 
-  const peersWithAliases = (peers?.connected || []).filter(
-    (peer) => aliases && peer.address && aliases[peer.address],
-  );
+  const peersWithAliases = (peers?.connected || []).filter((peer) => aliases && peer.address && aliases[peer.address]);
   const peersWithAliasesSorted = peersWithAliases.sort((a, b) => {
     if (getAliasByAddress(b.address).toLowerCase() > getAliasByAddress(a.address).toLowerCase()) {
       return -1;
@@ -148,11 +146,7 @@ function PeersPage() {
 
     return {
       id: index + 1,
-      node: (
-        <PeersInfo
-          nodeAddress={peer.address}
-        />
-      ),
+      node: <PeersInfo nodeAddress={peer.address} />,
       address: getAliasByAddress(peer.address),
       peerAddress: peer.address,
       quality: <ProgressBar value={peer.quality} />,
@@ -160,9 +154,7 @@ function PeersPage() {
       actions: (
         <>
           <PingModal address={peer.address} />
-          <CreateAliasModal
-            address={peer.address}
-          />
+          <CreateAliasModal address={peer.address} />
           {nodeAddressToOutgoingChannelLink[peer.address] ? (
             <FundChannelModal channelId={nodeAddressToOutgoingChannelLink[peer.address]} />
           ) : (

--- a/src/pages/node/peers.tsx
+++ b/src/pages/node/peers.tsx
@@ -29,7 +29,6 @@ function PeersPage() {
   const peersFetching = useAppSelector((store) => store.node.peers.isFetching);
   const aliases = useAppSelector((store) => store.node.aliases);
   const nodeAddressToOutgoingChannelLink = useAppSelector((store) => store.node.links.nodeAddressToOutgoingChannel);
-  const peerIdToAliasLink = useAppSelector((store) => store.node.links.peerIdToAlias);
 
   useEffect(() => {
     handleRefresh();
@@ -46,9 +45,9 @@ function PeersPage() {
     );
   };
 
-  const getAliasByPeerId = (peerId: string): string => {
-    if (aliases && peerId && peerIdToAliasLink[peerId]) return `${peerIdToAliasLink[peerId]} (${peerId})`;
-    return peerId;
+  const getAliasByAddress = (address: string): string => {
+    if (aliases && address && aliases[address]) return `${aliases[address]} (${address})`;
+    return address;
   };
 
   const handleExport = () => {
@@ -80,13 +79,7 @@ function PeersPage() {
       maxWidth: '300px',
     },
     {
-      key: 'peerId',
-      name: 'Peer Id',
-      search: true,
-      hidden: true,
-    },
-    {
-      key: 'peerAddress',
+      key: 'address',
       name: 'Node Address',
       search: true,
       hidden: true,
@@ -112,19 +105,19 @@ function PeersPage() {
   ];
 
   const peersWithAliases = (peers?.connected || []).filter(
-    (peer) => aliases && peer.address && peerIdToAliasLink[peer.address],
+    (peer) => aliases && peer.address && aliases[peer.address],
   );
   const peersWithAliasesSorted = peersWithAliases.sort((a, b) => {
-    if (getAliasByPeerId(b.address).toLowerCase() > getAliasByPeerId(a.address).toLowerCase()) {
+    if (getAliasByAddress(b.address).toLowerCase() > getAliasByAddress(a.address).toLowerCase()) {
       return -1;
     }
-    if (getAliasByPeerId(b.address).toLowerCase() < getAliasByPeerId(a.address).toLowerCase()) {
+    if (getAliasByAddress(b.address).toLowerCase() < getAliasByAddress(a.address).toLowerCase()) {
       return 1;
     }
     return 0;
   });
   const peersWithoutAliases = (peers?.connected || []).filter(
-    (peer) => aliases && peer.address && !peerIdToAliasLink[peer.address],
+    (peer) => aliases && peer.address && !aliases[peer.address],
   );
   const peersWithoutAliasesSorted = peersWithoutAliases.sort((a, b) => {
     if (b.address > a.address) {
@@ -157,22 +150,19 @@ function PeersPage() {
       id: index + 1,
       node: (
         <PeersInfo
-          peerId={''}
           nodeAddress={peer.address}
-          shortenPeerIdIfAliasPresent
         />
       ),
-      peerId: getAliasByPeerId(peer.address),
+      address: getAliasByAddress(peer.address),
       peerAddress: peer.address,
       quality: <ProgressBar value={peer.quality} />,
       lastSeen: <span style={{ whiteSpace: 'break-spaces' }}>{lastSeen}</span>,
       actions: (
         <>
           <PingModal address={peer.address} />
-          {/* <CreateAliasModal
-            handleRefresh={handleRefresh}
-            peerId={peer.address}
-          /> */}
+          <CreateAliasModal
+            address={peer.address}
+          />
           {nodeAddressToOutgoingChannelLink[peer.address] ? (
             <FundChannelModal channelId={nodeAddressToOutgoingChannelLink[peer.address]} />
           ) : (

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -17,7 +17,7 @@ import { nodeActions, nodeActionsAsync } from './store/slices/node';
 
 // Sections
 import NodeLandingPage from './pages/node/landingPage';
-//import AliasesPage from './pages/node/aliases';
+import AliasesPage from './pages/node/aliases';
 import InfoPage from './pages/node/info';
 //import MessagesPage from './pages/node/messages';
 import PeersPage from './pages/node/peers';
@@ -129,14 +129,14 @@ export const applicationMapNode: ApplicationMapType = [
         numberKey: 'numberOfPeers',
         fetchingKey: 'fetchingPeers',
       },
-      // {
-      //   name: 'ALIASES',
-      //   path: 'aliases',
-      //   icon: <ContactPhone />,
-      //   element: <AliasesPage />,
-      //   loginNeeded: 'node',
-      //   numberKey: 'numberOfAliases',
-      // },
+      {
+        name: 'ALIASES',
+        path: 'aliases',
+        icon: <ContactPhone />,
+        element: <AliasesPage />,
+        loginNeeded: 'node',
+        numberKey: 'numberOfAliases',
+      },
       // {
       //   name: 'MESSAGES',
       //   path: 'messages',

--- a/src/store/slices/node/actionsAsync.ts
+++ b/src/store/slices/node/actionsAsync.ts
@@ -132,8 +132,8 @@ const getInfoThunk = createAsyncThunk<GetInfoResponseType | undefined, BasePaylo
 
 const getAddressesThunk = createAsyncThunk<
   | {
-      native: string;
-    }
+    native: string;
+  }
   | undefined,
   BasePayloadType & { force?: boolean },
   { state: RootState }
@@ -462,9 +462,9 @@ const withdrawThunk = createAsyncThunk<string | undefined, WithdrawPayloadType, 
 
 const closeChannelThunk = createAsyncThunk<
   | {
-      channelStatus: string;
-      receipt?: string | undefined;
-    }
+    channelStatus: string;
+    receipt?: string | undefined;
+  }
   | undefined,
   CloseChannelPayloadType,
   { state: RootState }
@@ -1079,6 +1079,14 @@ export const createAsyncReducer = (builder: ActionReducerMapBuilder<typeof initi
         connected: [],
       };
       state.peers.data = action.payload;
+      const sortedConnectedPeers = action.payload?.connected
+        .map((peer) => peer.address)
+        .sort();
+      const sortedAnnouncedPeers = action.payload?.announced
+        .map((peer) => peer.address)
+        .sort();
+      state.peers.parsed.connectedSorted = sortedConnectedPeers || [];
+      state.peers.parsed.announcedSorted = sortedAnnouncedPeers || [];
     }
 
     if (!state.peers.alreadyFetched) state.peers.alreadyFetched = true;

--- a/src/store/slices/node/actionsAsync.ts
+++ b/src/store/slices/node/actionsAsync.ts
@@ -132,8 +132,8 @@ const getInfoThunk = createAsyncThunk<GetInfoResponseType | undefined, BasePaylo
 
 const getAddressesThunk = createAsyncThunk<
   | {
-    native: string;
-  }
+      native: string;
+    }
   | undefined,
   BasePayloadType & { force?: boolean },
   { state: RootState }
@@ -462,9 +462,9 @@ const withdrawThunk = createAsyncThunk<string | undefined, WithdrawPayloadType, 
 
 const closeChannelThunk = createAsyncThunk<
   | {
-    channelStatus: string;
-    receipt?: string | undefined;
-  }
+      channelStatus: string;
+      receipt?: string | undefined;
+    }
   | undefined,
   CloseChannelPayloadType,
   { state: RootState }
@@ -1079,12 +1079,8 @@ export const createAsyncReducer = (builder: ActionReducerMapBuilder<typeof initi
         connected: [],
       };
       state.peers.data = action.payload;
-      const sortedConnectedPeers = action.payload?.connected
-        .map((peer) => peer.address)
-        .sort();
-      const sortedAnnouncedPeers = action.payload?.announced
-        .map((peer) => peer.address)
-        .sort();
+      const sortedConnectedPeers = action.payload?.connected.map((peer) => peer.address).sort();
+      const sortedAnnouncedPeers = action.payload?.announced.map((peer) => peer.address).sort();
       state.peers.parsed.connectedSorted = sortedConnectedPeers || [];
       state.peers.parsed.announcedSorted = sortedAnnouncedPeers || [];
     }

--- a/src/store/slices/node/index.ts
+++ b/src/store/slices/node/index.ts
@@ -26,6 +26,7 @@ const nodeSlice = createSlice({
       if (state.messages.data.length > 100)
         state.messages.data = state.messages.data.slice(state.messages.data.length - 100, state.messages.data.length);
     },
+    // handle checkboxes
     toggleMessageSeen(state, action: PayloadAction<(typeof initialState.messages.data)[0]>) {
       state.messages.data = state.messages.data.map((message) => {
         if (message.id === action.payload.id) {
@@ -50,6 +51,22 @@ const nodeSlice = createSlice({
     removeAllCheckboxes(state, action: PayloadAction<{ category: 'peers'|'channelsIn'|'channelsOut'|'sessions' }>) {
       const category = action.payload.category;
       state.checks[category] = {};
+    },
+    // handle aliases
+    setAlias(state, action: PayloadAction<{ nodeAddress: string; alias: string }>) {
+      const nodeAddress = action.payload.nodeAddress;
+      const alias = action.payload.alias;
+      if (!nodeAddress || !alias) return;
+      state.aliases = {
+        ...state.aliases,
+        [nodeAddress]: alias,
+      };
+    },
+    removeAlias(state, action: PayloadAction<string>) {
+      const nodeAddress = action.payload;
+      if (state.aliases[nodeAddress]) {
+        delete state.aliases[nodeAddress];
+      }
     },
     // handle ws state
     updateMessagesWebsocketStatus(state, action: PayloadAction<typeof initialState.messagesWebsocketStatus>) {

--- a/src/store/slices/node/index.ts
+++ b/src/store/slices/node/index.ts
@@ -40,17 +40,27 @@ const nodeSlice = createSlice({
         return message;
       });
     },
-    toggleCheckbox(state, action: PayloadAction<{ category: 'peers'|'channelsIn'|'channelsOut'|'sessions'; id: string, checked: boolean }>) {
+    toggleCheckbox(
+      state,
+      action: PayloadAction<{
+        category: 'peers' | 'channelsIn' | 'channelsOut' | 'sessions';
+        id: string;
+        checked: boolean;
+      }>,
+    ) {
       const category = action.payload.category;
       const id = action.payload.id;
       const checked = action.payload.checked;
-      if(checked) {
+      if (checked) {
         state.checks[category][id] = true;
       } else {
         delete state.checks[category][id];
       }
     },
-    removeAllCheckboxes(state, action: PayloadAction<{ category: 'peers'|'channelsIn'|'channelsOut'|'sessions' }>) {
+    removeAllCheckboxes(
+      state,
+      action: PayloadAction<{ category: 'peers' | 'channelsIn' | 'channelsOut' | 'sessions' }>,
+    ) {
       const category = action.payload.category;
       state.checks[category] = {};
     },

--- a/src/store/slices/node/index.ts
+++ b/src/store/slices/node/index.ts
@@ -69,9 +69,8 @@ const nodeSlice = createSlice({
       const nodeAddress = action.payload;
       if (!isAddress(nodeAddress)) return;
       const nodeAddressValidated = getAddress(nodeAddress);
-      const aliasesString = loadStateFromLocalStorage(`node/aliases/${nodeAddressValidated}`) as string;
-      if (aliasesString) {
-        const aliases = JSON.parse(aliasesString);
+      const aliases = loadStateFromLocalStorage(`node/aliases/${nodeAddressValidated}`);
+      if (aliases) {
         state.aliases = aliases as {
           [key: string]: string;
         };

--- a/src/store/slices/node/index.ts
+++ b/src/store/slices/node/index.ts
@@ -78,6 +78,9 @@ const nodeSlice = createSlice({
           const alias = aliases[nodeAddress];
           state.links.aliasToNodeAddress[alias] = nodeAddress;
         });
+        const sortedAliases = Object.values(aliases).sort();
+        state.links.sortedAliases = sortedAliases;
+        state.links.nodeAddressesWithAliases = Object.keys(aliases);
       }
     },
     setAlias(state, action: PayloadAction<{ nodeAddress: string; alias: string }>) {
@@ -88,6 +91,9 @@ const nodeSlice = createSlice({
       delete state.links.aliasToNodeAddress[state.aliases[nodeAddressValidated]];
       state.aliases[nodeAddressValidated] = alias;
       state.links.aliasToNodeAddress[alias] = nodeAddressValidated;
+      const sortedAliases = Object.values(state.aliases).sort();
+      state.links.sortedAliases = sortedAliases;
+      state.links.nodeAddressesWithAliases = Object.keys(state.aliases);
       saveStateToLocalStorage(`node/aliases/${state.addresses.data.native}`, state.aliases);
     },
     removeAlias(state, action: PayloadAction<string>) {
@@ -95,6 +101,9 @@ const nodeSlice = createSlice({
       if (state.aliases[nodeAddress]) {
         delete state.links.aliasToNodeAddress[state.aliases[nodeAddress]];
         delete state.aliases[nodeAddress];
+        const sortedAliases = Object.values(state.aliases).sort();
+        state.links.sortedAliases = sortedAliases;
+        state.links.nodeAddressesWithAliases = Object.keys(state.aliases);
       }
       saveStateToLocalStorage(`node/aliases/${state.addresses.data.native}`, state.aliases);
     },

--- a/src/store/slices/node/index.ts
+++ b/src/store/slices/node/index.ts
@@ -70,7 +70,7 @@ const nodeSlice = createSlice({
       if (!isAddress(nodeAddress)) return;
       const nodeAddressValidated = getAddress(nodeAddress);
       const aliases = loadStateFromLocalStorage(`node/aliases/${nodeAddressValidated}`) as {
-          [key: string]: string;
+        [key: string]: string;
       } | null;
       if (aliases) {
         state.aliases = aliases;
@@ -78,7 +78,9 @@ const nodeSlice = createSlice({
           const alias = aliases[nodeAddress];
           state.links.aliasToNodeAddress[alias] = nodeAddress;
         });
-        const sortedAliases = Object.values(aliases).sort();
+        const sortedAliases = Object.values(aliases).sort((a, b) =>
+          a.localeCompare(b, undefined, { sensitivity: 'base' }),
+        );
         state.links.sortedAliases = sortedAliases;
         state.links.nodeAddressesWithAliases = Object.keys(aliases);
       }
@@ -91,7 +93,9 @@ const nodeSlice = createSlice({
       delete state.links.aliasToNodeAddress[state.aliases[nodeAddressValidated]];
       state.aliases[nodeAddressValidated] = alias;
       state.links.aliasToNodeAddress[alias] = nodeAddressValidated;
-      const sortedAliases = Object.values(state.aliases).sort();
+      const sortedAliases = Object.values(state.aliases).sort((a, b) =>
+        a.localeCompare(b, undefined, { sensitivity: 'base' }),
+      );
       state.links.sortedAliases = sortedAliases;
       state.links.nodeAddressesWithAliases = Object.keys(state.aliases);
       saveStateToLocalStorage(`node/aliases/${state.addresses.data.native}`, state.aliases);
@@ -101,7 +105,9 @@ const nodeSlice = createSlice({
       if (state.aliases[nodeAddress]) {
         delete state.links.aliasToNodeAddress[state.aliases[nodeAddress]];
         delete state.aliases[nodeAddress];
-        const sortedAliases = Object.values(state.aliases).sort();
+        const sortedAliases = Object.values(state.aliases).sort((a, b) =>
+          a.localeCompare(b, undefined, { sensitivity: 'base' }),
+        );
         state.links.sortedAliases = sortedAliases;
         state.links.nodeAddressesWithAliases = Object.keys(state.aliases);
       }

--- a/src/store/slices/node/index.ts
+++ b/src/store/slices/node/index.ts
@@ -37,6 +37,20 @@ const nodeSlice = createSlice({
         return message;
       });
     },
+    toggleCheckbox(state, action: PayloadAction<{ category: 'peers'|'channelsIn'|'channelsOut'|'sessions'; id: string, checked: boolean }>) {
+      const category = action.payload.category;
+      const id = action.payload.id;
+      const checked = action.payload.checked;
+      if(checked) {
+        state.checks[category][id] = true;
+      } else {
+        delete state.checks[category][id];
+      }
+    },
+    removeAllCheckboxes(state, action: PayloadAction<{ category: 'peers'|'channelsIn'|'channelsOut'|'sessions' }>) {
+      const category = action.payload.category;
+      state.checks[category] = {};
+    },
     // handle ws state
     updateMessagesWebsocketStatus(state, action: PayloadAction<typeof initialState.messagesWebsocketStatus>) {
       state.messagesWebsocketStatus = action.payload;

--- a/src/store/slices/node/index.ts
+++ b/src/store/slices/node/index.ts
@@ -69,10 +69,13 @@ const nodeSlice = createSlice({
       const nodeAddress = action.payload;
       if (!isAddress(nodeAddress)) return;
       const nodeAddressValidated = getAddress(nodeAddress);
-      const aliases = loadStateFromLocalStorage(`node/aliases/${nodeAddressValidated}`);
-      state.aliases = aliases as {
-        [key: string]: string;
-      };
+      const aliasesString = loadStateFromLocalStorage(`node/aliases/${nodeAddressValidated}`) as string;
+      if (aliasesString) {
+        const aliases = JSON.parse(aliasesString);
+        state.aliases = aliases as {
+          [key: string]: string;
+        };
+      }
     },
     setAlias(state, action: PayloadAction<{ nodeAddress: string; alias: string }>) {
       const nodeAddress = action.payload.nodeAddress;

--- a/src/store/slices/node/initialState.ts
+++ b/src/store/slices/node/initialState.ts
@@ -142,8 +142,8 @@ type InitialState = {
     aliasToNodeAddress: {
       [alias: string]: string;
     };
-    sortedAliases: string[],
-    nodeAddressesWithAliases: string[],
+    sortedAliases: string[];
+    nodeAddressesWithAliases: string[];
   };
   messages: {
     data: Message[];

--- a/src/store/slices/node/initialState.ts
+++ b/src/store/slices/node/initialState.ts
@@ -66,7 +66,9 @@ type InitialState = {
     data: AddressesType;
     isFetching: boolean;
   };
-  aliases: {};
+  aliases: {
+    [peerAddress: string]: string;
+  };
   balances: {
     data: {
       hopr: {
@@ -109,6 +111,20 @@ type InitialState = {
     isFetching: boolean;
     alreadyFetched: boolean;
   };
+  checks: {
+    peers: {
+      [peerAddress: string]: boolean;
+    },
+    channelsIn: {
+      [channelsId: string]: boolean;
+    },
+    channelsOut: {
+      [channelsId: string]: boolean;
+    },
+    sessions: {
+      [session: string]: boolean;
+    },
+  }
   configuration: {
     data: GetConfigurationResponseType | null;
     isFetching: boolean;
@@ -127,9 +143,6 @@ type InitialState = {
       [nodeAddress: string]: string;
     };
     peerIdToNodeAddress: {
-      [peerId: string]: string;
-    };
-    peerIdToAlias: {
       [peerId: string]: string;
     };
   };
@@ -298,6 +311,12 @@ export const initialState: InitialState = {
     isFetching: false,
     alreadyFetched: false,
   },
+  checks: {
+    peers: {},
+    channelsIn: {},
+    channelsOut: {},
+    sessions: {},
+  },
   configuration: {
     data: null,
     isFetching: false,
@@ -390,7 +409,6 @@ export const initialState: InitialState = {
     incomingChannelToNodeAddress: {},
     nodeAddressToPeerId: {},
     peerIdToNodeAddress: {},
-    peerIdToAlias: {},
   },
   apiEndpoint: null,
   nodeIsReady: {

--- a/src/store/slices/node/initialState.ts
+++ b/src/store/slices/node/initialState.ts
@@ -139,11 +139,8 @@ type InitialState = {
     incomingChannelToNodeAddress: {
       [channelId: string]: string;
     };
-    nodeAddressToPeerId: {
-      [nodeAddress: string]: string;
-    };
-    peerIdToNodeAddress: {
-      [peerId: string]: string;
+    aliasToNodeAddress: {
+      [alias: string]: string;
     };
   };
   messages: {
@@ -174,6 +171,8 @@ type InitialState = {
           reportedVersion: string;
         };
       };
+      connectedSorted: string[];
+      announcedSorted: string[];
     };
     isFetching: boolean;
     alreadyFetched: boolean;
@@ -332,6 +331,8 @@ export const initialState: InitialState = {
     data: null,
     parsed: {
       connected: {},
+      connectedSorted: [],
+      announcedSorted: [],
     },
     isFetching: false,
     alreadyFetched: false,
@@ -407,8 +408,7 @@ export const initialState: InitialState = {
     nodeAddressToOutgoingChannel: {},
     nodeAddressToIncomingChannel: {},
     incomingChannelToNodeAddress: {},
-    nodeAddressToPeerId: {},
-    peerIdToNodeAddress: {},
+    aliasToNodeAddress: {},
   },
   apiEndpoint: null,
   nodeIsReady: {

--- a/src/store/slices/node/initialState.ts
+++ b/src/store/slices/node/initialState.ts
@@ -142,6 +142,8 @@ type InitialState = {
     aliasToNodeAddress: {
       [alias: string]: string;
     };
+    sortedAliases: string[],
+    nodeAddressesWithAliases: string[],
   };
   messages: {
     data: Message[];
@@ -409,6 +411,8 @@ export const initialState: InitialState = {
     nodeAddressToIncomingChannel: {},
     incomingChannelToNodeAddress: {},
     aliasToNodeAddress: {},
+    sortedAliases: [],
+    nodeAddressesWithAliases: [],
   },
   apiEndpoint: null,
   nodeIsReady: {

--- a/src/store/slices/node/initialState.ts
+++ b/src/store/slices/node/initialState.ts
@@ -114,17 +114,17 @@ type InitialState = {
   checks: {
     peers: {
       [peerAddress: string]: boolean;
-    },
+    };
     channelsIn: {
       [channelsId: string]: boolean;
-    },
+    };
     channelsOut: {
       [channelsId: string]: boolean;
-    },
+    };
     sessions: {
       [session: string]: boolean;
-    },
-  }
+    };
+  };
   configuration: {
     data: GetConfigurationResponseType | null;
     isFetching: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -776,10 +776,10 @@
   resolved "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
-"@hoprnet/hopr-sdk@3.0.0-alpha.10":
-  version "3.0.0-alpha.10"
-  resolved "https://registry.yarnpkg.com/@hoprnet/hopr-sdk/-/hopr-sdk-3.0.0-alpha.10.tgz#5ee029c5ea94c9176daa81b45d63d2886c1f4ea4"
-  integrity sha512-u+aLmJr/SBXwA3pyr3wdsBJonh1eYmbPMplqmw8/qa0ss+P/QRfdkpiLjaO0tHYZ6o/pWyN3+LZrdx+3QCoolQ==
+"@hoprnet/hopr-sdk@3.0.0-alpha.12":
+  version "3.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/@hoprnet/hopr-sdk/-/hopr-sdk-3.0.0-alpha.12.tgz#e79be9365184fa2ca8af1adc01a21015e8ebfffb"
+  integrity sha512-iT8n4UPUJvpLA85RhGdzJhG9XYKz5KhYDR9JdjG/cdam6hUiv2+V6aF2vOO2xG7V8Q+/1ZxCufvfWuEGLynoxw==
   dependencies:
     debug "^4.3.4"
     isomorphic-ws "^5.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to manage node aliases directly by node address, including creating, editing, and deleting aliases.
  - Introduced address validation when adding or editing aliases.
  - Added a password visibility toggle for the API token input in the node connection modal.
  - Enabled checkboxes for selecting peers, channels, and sessions.

- **Improvements**
  - Simplified alias management by removing peer ID mapping; all alias-related actions now use node addresses.
  - Updated tables and modals to display and manage aliases by node address.
  - Improved CSV import/export for aliases, now using node addresses as keys.
  - Enhanced UI clarity by updating placeholders and labels to use addresses instead of peer IDs.
  - Activated the Aliases page route in the navigation.
  - Replaced text inputs with autocomplete components for selecting peer addresses in relevant modals.
  - Streamlined alias resolution and display logic across multiple components to rely solely on node addresses and aliases.

- **Bug Fixes**
  - Fixed issues related to alias resolution and display by standardizing on node addresses throughout the app.

- **Chores**
  - Updated dependencies to latest alpha versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->