### PR TITLE
V3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@fontsource/roboto": "^5.0.0",
-    "@hoprnet/hopr-sdk": "3.0.3-pr.156-20250915124445",
+    "@hoprnet/hopr-sdk": "3.0.3-pr.156-20250916114518",
     "@metamask/jazzicon": "^2.0.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@fontsource/roboto": "^5.0.0",
-    "@hoprnet/hopr-sdk": "3.0.3-pr.156-20250910174548",
+    "@hoprnet/hopr-sdk": "3.0.3-pr.156-20250915124445",
     "@metamask/jazzicon": "^2.0.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.0",

--- a/src/components/Modal/node/OpenSessionModal.tsx
+++ b/src/components/Modal/node/OpenSessionModal.tsx
@@ -129,8 +129,8 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
   const aliases = useAppSelector((store) => store.node.aliases);
 
   const [destination, set_destination] = useState<string | null>(props.destination ? props.destination : null);
-  const [listenHost, set_listenHost] = useState<string>('');//('127.0.0.1:10000');
-  const [sessionTarget, set_sessionTarget] = useState<string>('');//('127.0.0.1:8080');
+  const [listenHost, set_listenHost] = useState<string>(''); //('127.0.0.1:10000');
+  const [sessionTarget, set_sessionTarget] = useState<string>(''); //('127.0.0.1:8080');
   const [intermediateForwardPath, set_intermediateForwardPath] = useState<(string | null)[]>([null]);
   const [intermediateReturnPath, set_intermediateReturnPath] = useState<(string | null)[]>([null]);
   const fullForwardPath = [...intermediateForwardPath, destination];
@@ -443,7 +443,7 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
                 max: 10000,
                 step: 1,
               }}
-              type='number'
+              type="number"
               style={{
                 width: '97px',
               }}
@@ -530,7 +530,7 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
                   label="Retransmission"
                   onChange={() => {
                     set_retransmission((retransmission) => {
-                      if(!retransmission) {
+                      if (!retransmission) {
                         set_segmentation(true);
                       }
                       return !retransmission;
@@ -542,7 +542,7 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
                   label="RetransmissionAckOnly"
                   onChange={() => {
                     set_retransmissionAckOnly((retransmissionAckOnly) => {
-                      if(!retransmissionAckOnly) {
+                      if (!retransmissionAckOnly) {
                         set_segmentation(true);
                       }
                       return !retransmissionAckOnly;
@@ -554,13 +554,14 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
                   label="Segmentation"
                   disabled={noDelay || retransmission || retransmissionAckOnly}
                   title={
-                    retransmission ?
-                    'Segmentation is required when Retransmission is enabled' :
-                      retransmissionAckOnly ?
-                      'Segmentation is required when RetransmissionAckOnly is enabled' :
-                      noDelay ?
-                      'Segmentation is required when NoDelay is enabled' :
-                      ''}
+                    retransmission
+                      ? 'Segmentation is required when Retransmission is enabled'
+                      : retransmissionAckOnly
+                      ? 'Segmentation is required when RetransmissionAckOnly is enabled'
+                      : noDelay
+                      ? 'Segmentation is required when NoDelay is enabled'
+                      : ''
+                  }
                   onChange={() => {
                     set_segmentation((segmentation) => {
                       return !segmentation;
@@ -572,7 +573,7 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
                   label="NoDelay"
                   onChange={() => {
                     set_noDelay((noDelay) => {
-                      if(!noDelay) {
+                      if (!noDelay) {
                         set_segmentation(true);
                       }
                       return !noDelay;

--- a/src/components/Modal/node/OpenSessionModal.tsx
+++ b/src/components/Modal/node/OpenSessionModal.tsx
@@ -184,14 +184,6 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
   useEffect(setPropPeerId, [props.destination]);
 
   useEffect(() => {
-    console.log('intermediateForwardPathError', intermediateForwardPathError);
-  }, [intermediateForwardPathError]);
-
-  useEffect(() => {
-    console.log('intermediateReturnPathError', intermediateReturnPathError);
-  }, [intermediateReturnPathError]);
-
-  useEffect(() => {
     window.addEventListener('keydown', handleEnter as EventListener);
     return () => {
       window.removeEventListener('keydown', handleEnter as EventListener);

--- a/src/components/Modal/node/OpenSessionModal.tsx
+++ b/src/components/Modal/node/OpenSessionModal.tsx
@@ -117,15 +117,20 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
   const [sendReturnMode, set_sendReturnMode] = useState<'path' | 'numberOfHops'>('numberOfHops');
   const [protocol, set_protocol] = useState<'udp' | 'tcp'>('udp');
   const [responseBuffer, set_responseBuffer] = useState<number>(2048);
+  const [maxSurbUpstream, set_maxSurbUpstream] = useState<number>(2000);
+  const [maxClientSessions, set_maxClientSessions] = useState<number>(5);
   const [retransmission, set_retransmission] = useState<boolean>(true);
+  const [retransmissionAckOnly, set_retransmissionAckOnly] = useState<boolean>(false);
+  const [noDelay, set_noDelay] = useState<boolean>(false);
+  const [noRateControl, set_noRateControl] = useState<boolean>(false);
   const [segmentation, set_segmentation] = useState<boolean>(true);
   const [openModal, set_openModal] = useState<boolean>(false);
   const loginData = useAppSelector((store) => store.auth.loginData);
   const aliases = useAppSelector((store) => store.node.aliases);
 
   const [destination, set_destination] = useState<string | null>(props.destination ? props.destination : null);
-  const [listenHost, set_listenHost] = useState<string>('');
-  const [sessionTarget, set_sessionTarget] = useState<string>('');
+  const [listenHost, set_listenHost] = useState<string>('127.0.0.1:10000');
+  const [sessionTarget, set_sessionTarget] = useState<string>('127.0.0.1:8080');
   const [intermediateForwardPath, set_intermediateForwardPath] = useState<(string | null)[]>([null]);
   const [intermediateReturnPath, set_intermediateReturnPath] = useState<(string | null)[]>([null]);
   const fullForwardPath = [...intermediateForwardPath, destination];
@@ -229,6 +234,8 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
       forwardPath: {},
       returnPath: {},
       responseBuffer: `${responseBuffer} kB`,
+      maxSurbUpstream: `${maxSurbUpstream} kb/s`,
+      maxClientSessions: maxClientSessions,
     };
 
     if (sendForwardMode === 'numberOfHops') {
@@ -255,8 +262,17 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
     if (retransmission) {
       sessionPayload.capabilities.push('Retransmission');
     }
+    if (retransmissionAckOnly) {
+      sessionPayload.capabilities.push('RetransmissionAckOnly');
+    }
     if (segmentation) {
       sessionPayload.capabilities.push('Segmentation');
+    }
+    if (noDelay) {
+      sessionPayload.capabilities.push('NoDelay');
+    }
+    if (noRateControl) {
+      sessionPayload.capabilities.push('NoRateControl');
     }
 
     dispatch(actionsAsync.openSessionThunk(sessionPayload))
@@ -364,7 +380,7 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
             <span>
               OPEN
               <br />
-              session
+              session listener
             </span>
           )
         }
@@ -376,10 +392,10 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
         open={openModal}
         onClose={handleCloseModal}
         disableScrollLock={true}
-        maxWidth={'800px'}
+        maxWidth={'750px'}
       >
         <TopBar>
-          <DialogTitle>Open session</DialogTitle>
+          <DialogTitle>Open session listener</DialogTitle>
           <SIconButton
             aria-label="close modal"
             onClick={handleCloseModal}
@@ -388,39 +404,87 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
           </SIconButton>
         </TopBar>
         <SDialogContent>
-          <Autocomplete
-            value={destination}
-            onChange={(event, newValue) => {
-              set_destination(newValue);
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              gap: '8px',
             }}
-            options={addressBook}
-            getOptionLabel={(address) => (aliases[address] ? `${aliases[address]} (${address})` : address)}
-            autoSelect
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                label="Destination"
-                placeholder="Select Destination"
-                fullWidth
-              />
-            )}
-            // renderOption={(option)=>{
-            //   return (
-            //     <span>
-            //       {JSON.stringify(option)}
-            //     </span>
-            //   )
-            // }}
-          />
-          <TextField
-            label="Listen host"
-            placeholder={'127.0.0.1:10000'}
-            value={listenHost}
-            onChange={(event) => {
-              set_listenHost(event?.target?.value);
+          >
+            <Autocomplete
+              value={destination}
+              onChange={(event, newValue) => {
+                set_destination(newValue);
+              }}
+              options={addressBook}
+              getOptionLabel={(address) => (aliases[address] ? `${aliases[address]} (${address})` : address)}
+              autoSelect
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Destination"
+                  placeholder="Select Destination"
+                  fullWidth
+                />
+              )}
+              style={{
+                flex: 1,
+              }}
+            />
+            <TextField
+              label="Max client"
+              value={maxClientSessions}
+              onChange={(event) => {
+                set_maxClientSessions(Number(event?.target?.value));
+              }}
+              inputProps={{
+                type: 'number',
+                min: 1,
+                max: 10000,
+                step: 1,
+              }}
+              type='number'
+              style={{
+                width: '97px',
+              }}
+            />
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              gap: '8px',
             }}
-            fullWidth
-          />
+          >
+            <TextField
+              label="Listen host"
+              placeholder={'127.0.0.1:10000'}
+              value={listenHost}
+              onChange={(event) => {
+                set_listenHost(event?.target?.value);
+              }}
+              fullWidth
+            />
+            <TextField
+              label="Max surb upstream"
+              value={maxSurbUpstream}
+              onChange={(event) => {
+                set_maxSurbUpstream(Number(event?.target?.value));
+              }}
+              inputProps={{
+                type: 'number',
+                min: 1,
+                max: 10000,
+                step: 1,
+              }}
+              InputProps={{
+                endAdornment: <InputAdornment position="end">kb/s</InputAdornment>,
+              }}
+              style={{
+                width: '170px',
+              }}
+            />
+          </div>
           <div
             style={{
               display: 'flex',
@@ -466,16 +530,62 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
                   label="Retransmission"
                   onChange={() => {
                     set_retransmission((retransmission) => {
+                      if(!retransmission) {
+                        set_segmentation(true);
+                      }
                       return !retransmission;
+                    });
+                  }}
+                />
+                <FormControlLabel
+                  control={<Checkbox checked={retransmissionAckOnly} />}
+                  label="RetransmissionAckOnly"
+                  onChange={() => {
+                    set_retransmissionAckOnly((retransmissionAckOnly) => {
+                      if(!retransmissionAckOnly) {
+                        set_segmentation(true);
+                      }
+                      return !retransmissionAckOnly;
                     });
                   }}
                 />
                 <FormControlLabel
                   control={<Checkbox checked={segmentation} />}
                   label="Segmentation"
+                  disabled={noDelay || retransmission || retransmissionAckOnly}
+                  title={
+                    retransmission ?
+                    'Segmentation is required when Retransmission is enabled' :
+                      retransmissionAckOnly ?
+                      'Segmentation is required when RetransmissionAckOnly is enabled' :
+                      noDelay ?
+                      'Segmentation is required when NoDelay is enabled' :
+                      ''}
                   onChange={() => {
                     set_segmentation((segmentation) => {
                       return !segmentation;
+                    });
+                  }}
+                />
+                <FormControlLabel
+                  control={<Checkbox checked={noDelay} />}
+                  label="NoDelay"
+                  onChange={() => {
+                    set_noDelay((noDelay) => {
+                      if(!noDelay) {
+                        set_segmentation(true);
+                      }
+                      return !noDelay;
+                    });
+                  }}
+                />
+
+                <FormControlLabel
+                  control={<Checkbox checked={noRateControl} />}
+                  label="NoRateControl"
+                  onChange={() => {
+                    set_noRateControl((noRateControl) => {
+                      return !noRateControl;
                     });
                   }}
                 />

--- a/src/components/Modal/node/OpenSessionModal.tsx
+++ b/src/components/Modal/node/OpenSessionModal.tsx
@@ -129,8 +129,8 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
   const aliases = useAppSelector((store) => store.node.aliases);
 
   const [destination, set_destination] = useState<string | null>(props.destination ? props.destination : null);
-  const [listenHost, set_listenHost] = useState<string>('127.0.0.1:10000');
-  const [sessionTarget, set_sessionTarget] = useState<string>('127.0.0.1:8080');
+  const [listenHost, set_listenHost] = useState<string>('');//('127.0.0.1:10000');
+  const [sessionTarget, set_sessionTarget] = useState<string>('');//('127.0.0.1:8080');
   const [intermediateForwardPath, set_intermediateForwardPath] = useState<(string | null)[]>([null]);
   const [intermediateReturnPath, set_intermediateReturnPath] = useState<(string | null)[]>([null]);
   const fullForwardPath = [...intermediateForwardPath, destination];
@@ -341,9 +341,9 @@ export const OpenSessionModal = (props: OpenSessionModalProps) => {
   };
 
   const handleCloseModal = () => {
-    set_sendForwardMode('numberOfHops');
-    set_numberOfForwardHops(0);
-    set_destination(props.destination ? props.destination : null);
+    // set_sendForwardMode('numberOfHops');
+    // set_numberOfForwardHops(0);
+    // set_destination(props.destination ? props.destination : null);
     set_openModal(false);
     set_error(null);
   };

--- a/src/future-hopr-lib-components/Button/IconButton.tsx
+++ b/src/future-hopr-lib-components/Button/IconButton.tsx
@@ -70,7 +70,7 @@ export const IconButton = ({
     >
       <span>
         <SIconButton
-          disabled={disabled || pending}
+          disabled={disabled || pending || reloading}
           className={`${reloading ? 'reloading' : ''}`}
           onClick={onClick}
         >

--- a/src/pages/node/channelsOutgoing.tsx
+++ b/src/pages/node/channelsOutgoing.tsx
@@ -233,22 +233,7 @@ function ChannelsPage() {
                 ) : undefined
               }
             />
-            {/* <CreateAliasModal
-              handleRefresh={handleRefresh}
-              peerId={peerId}
-              disabled={!peerId}
-              tooltip={
-                !peerId ? (
-                  <span>
-                    DISABLED
-                    <br />
-                    Unable to find
-                    <br />
-                    peerId
-                  </span>
-                ) : undefined
-              }
-            /> */}
+            <CreateAliasModal address={peerAddress} />
             <FundChannelModal channelId={id} />
             <IconButton
               iconComponent={<CloseChannelIcon />}

--- a/src/pages/node/info/index.tsx
+++ b/src/pages/node/info/index.tsx
@@ -83,7 +83,7 @@ function InfoPage() {
         return;
       }
       const providerObject = new URL(provider);
-      const providerContainsSecret = providerObject.pathname !== '/' || providerObject.search !== "";
+      const providerContainsSecret = providerObject.pathname !== '/' || providerObject.search !== '';
       set_providerContainsSecret(providerContainsSecret);
       const providerShort = providerContainsSecret ? providerObject.origin + '/************' : provider;
       set_providerShort(providerShort || '');
@@ -92,7 +92,6 @@ function InfoPage() {
       set_providerShort('***Invalid URL***');
     }
   }, [provider]);
-
 
   useEffect(() => {
     const watchSync = setInterval(() => {
@@ -323,10 +322,9 @@ function InfoPage() {
                   >
                     <span style={{ display: 'flex', alignItems: 'center' }}>Provider address</span>
                   </Tooltip>
-                  {
-                    providerContainsSecret &&
+                  {providerContainsSecret && (
                     <>
-                      {showWholeProvider ?
+                      {showWholeProvider ? (
                         <IconButton
                           iconComponent={<Visibility />}
                           tooltipText={
@@ -339,9 +337,8 @@ function InfoPage() {
                           onClick={() => {
                             set_showWholeProvider(false);
                           }}
-
                         />
-                        :
+                      ) : (
                         <IconButton
                           iconComponent={<VisibilityOff />}
                           tooltipText={
@@ -355,16 +352,20 @@ function InfoPage() {
                             set_showWholeProvider(true);
                           }}
                         />
-                      }
+                      )}
                     </>
-                  }
+                  )}
                 </div>
               </th>
               <td>
                 {channelsCorrupted ? (
-                  <span style={{ color: 'red', fontWeight: 'bold' }}>Faulty RPC | {showWholeProvider ? provider : providerShort}</span>
+                  <span style={{ color: 'red', fontWeight: 'bold' }}>
+                    Faulty RPC | {showWholeProvider ? provider : providerShort}
+                  </span>
+                ) : showWholeProvider ? (
+                  provider
                 ) : (
-                  showWholeProvider ? provider : providerShort
+                  providerShort
                 )}
               </td>
             </tr>

--- a/src/pages/node/info/index.tsx
+++ b/src/pages/node/info/index.tsx
@@ -89,7 +89,7 @@ function InfoPage() {
       set_providerShort(providerShort || '');
     } catch (e) {
       console.error('Error parsing provider URL', e);
-      set_providerShort('')
+      set_providerShort('***Invalid URL***');
     }
   }, [provider]);
 

--- a/src/pages/node/info/index.tsx
+++ b/src/pages/node/info/index.tsx
@@ -7,6 +7,8 @@ import { formatEther } from 'viem';
 
 // Mui
 import { Paper } from '@mui/material';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import Visibility from '@mui/icons-material/Visibility';
 
 // HOPR Components
 import Section from '../../../future-hopr-lib-components/Section';
@@ -65,10 +67,32 @@ function InfoPage() {
   const ticketPrice = useAppSelector((store) => store.node.ticketPrice.data);
   const minimumNetworkProbability = useAppSelector((store) => store.node.probability.data);
   const channelsCorrupted = useAppSelector((store) => store.node.channels.corrupted.data.length > 0);
+  const [showWholeProvider, set_showWholeProvider] = useState(false);
+  const [providerShort, set_providerShort] = useState('');
+  const [providerContainsSecret, set_providerContainsSecret] = useState(true);
+  const provider = info?.provider;
 
   useEffect(() => {
     fetchInfoData();
   }, [apiEndpoint, apiToken]);
+
+  useEffect(() => {
+    try {
+      if (!provider) {
+        set_providerShort('');
+        return;
+      }
+      const providerObject = new URL(provider);
+      const providerContainsSecret = providerObject.pathname !== '/' || providerObject.search !== "";
+      set_providerContainsSecret(providerContainsSecret);
+      const providerShort = providerContainsSecret ? providerObject.origin + '/************' : provider;
+      set_providerShort(providerShort || '');
+    } catch (e) {
+      console.error('Error parsing provider URL', e);
+      set_providerShort('')
+    }
+  }, [provider]);
+
 
   useEffect(() => {
     const watchSync = setInterval(() => {
@@ -291,19 +315,56 @@ function InfoPage() {
               <td>{indexerDataSource || '-'}</td>
             </tr>
             <tr>
-              <th>
-                <Tooltip
-                  title="The RPC provider address your node uses sync"
-                  notWide
-                >
-                  <span>Provider address</span>
-                </Tooltip>
+              <th style={providerContainsSecret ? { padding: '3px 8px' } : {}}>
+                <div style={{ display: 'flex' }}>
+                  <Tooltip
+                    title="The RPC provider address your node uses sync"
+                    notWide
+                  >
+                    <span style={{ display: 'flex', alignItems: 'center' }}>Provider address</span>
+                  </Tooltip>
+                  {
+                    providerContainsSecret &&
+                    <>
+                      {showWholeProvider ?
+                        <IconButton
+                          iconComponent={<Visibility />}
+                          tooltipText={
+                            <span>
+                              HIDE
+                              <br />
+                              full URL
+                            </span>
+                          }
+                          onClick={() => {
+                            set_showWholeProvider(false);
+                          }}
+
+                        />
+                        :
+                        <IconButton
+                          iconComponent={<VisibilityOff />}
+                          tooltipText={
+                            <span>
+                              SHOW
+                              <br />
+                              full URL
+                            </span>
+                          }
+                          onClick={() => {
+                            set_showWholeProvider(true);
+                          }}
+                        />
+                      }
+                    </>
+                  }
+                </div>
               </th>
               <td>
                 {channelsCorrupted ? (
-                  <span style={{ color: 'red', fontWeight: 'bold' }}>Faulty RPC | {info?.provider}</span>
+                  <span style={{ color: 'red', fontWeight: 'bold' }}>Faulty RPC | {showWholeProvider ? provider : providerShort}</span>
                 ) : (
-                  info?.provider
+                  showWholeProvider ? provider : providerShort
                 )}
               </td>
             </tr>

--- a/src/pages/node/sessions.tsx
+++ b/src/pages/node/sessions.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import styled from '@emotion/styled';
 import { useAppDispatch, useAppSelector } from '../../store';
 import { actionsAsync } from '../../store/slices/node/actionsAsync';
 import { exportToCsv } from '../../utils/helpers';
@@ -14,10 +15,18 @@ import TablePro from '../../future-hopr-lib-components/Table/table-pro';
 
 // Modals
 import { OpenSessionModal } from '../../components/Modal/node/OpenSessionModal';
+import { PingModal } from '../../components/Modal/node/PingModal';
 
 // Mui
 import GetAppIcon from '@mui/icons-material/GetApp';
 import PhoneDisabledIcon from '@mui/icons-material/PhoneDisabled';
+
+const Hop = styled.div`
+  display: inline-flex;
+  align-items: center;
+  margin: 2px;
+  height: 18px;
+`
 
 function SessionsPage() {
   const dispatch = useAppDispatch();
@@ -157,19 +166,53 @@ function SessionsPage() {
           <strong>Forward path:</strong>
           <br />
           <span style={{ whiteSpace: 'break-spaces' }}>
-            {JSON.stringify(session.forwardPath)
+            {
+              JSON.stringify(session.forwardPath).includes('Hops') ?
+              JSON.stringify(session.forwardPath)
               .replace(/{|}|\[|\]|"/g, '')
               .replace('IntermediatePath:', 'IntermediatePath:\n')
-              .replace(/,/g, ' ')}
+              .replace(/,/g, ' ')
+              :
+              <>
+                {
+                  session?.forwardPath?.IntermediatePath?.map((hop: string, i: number) => (
+                    <Hop
+                      className="hop"
+                      key={`hop-f-${i}`}
+                    >
+                      {hop}
+                      {i === 0 && <PingModal address={hop} />}
+                    </Hop>
+                  ))
+                }
+              </>
+            }
           </span>
           <br />
           <strong>Return path:</strong>
           <br />
           <span style={{ whiteSpace: 'break-spaces' }}>
-            {JSON.stringify(session.forwardPath)
+            {
+              JSON.stringify(session.returnPath).includes('Hops') ?
+              JSON.stringify(session.returnPath)
               .replace(/{|}|\[|\]|"/g, '')
               .replace('IntermediatePath:', 'IntermediatePath:\n')
-              .replace(/,/g, ' ')}
+              .replace(/,/g, ' ')
+              :
+              <>
+                {
+                  session?.returnPath?.IntermediatePath?.map((hop: string, i: number) => (
+                    <Hop
+                      className="hop"
+                      key={`hop-r-${i}`}
+                    >
+                      {hop}
+                      {i === (session?.returnPath?.IntermediatePath?.length ?? 0) - 1 && <PingModal address={hop} />}
+                    </Hop>
+                  ))
+                }
+              </>
+            }
           </span>
         </>
       ),

--- a/src/pages/node/sessions.tsx
+++ b/src/pages/node/sessions.tsx
@@ -26,7 +26,7 @@ const Hop = styled.div`
   align-items: center;
   margin: 2px;
   height: 18px;
-`
+`;
 
 function SessionsPage() {
   const dispatch = useAppDispatch();
@@ -166,53 +166,47 @@ function SessionsPage() {
           <strong>Forward path:</strong>
           <br />
           <span style={{ whiteSpace: 'break-spaces' }}>
-            {
-              JSON.stringify(session.forwardPath).includes('Hops') ?
+            {JSON.stringify(session.forwardPath).includes('Hops') ? (
               JSON.stringify(session.forwardPath)
-              .replace(/{|}|\[|\]|"/g, '')
-              .replace('IntermediatePath:', 'IntermediatePath:\n')
-              .replace(/,/g, ' ')
-              :
+                .replace(/{|}|\[|\]|"/g, '')
+                .replace('IntermediatePath:', 'IntermediatePath:\n')
+                .replace(/,/g, ' ')
+            ) : (
               <>
-                {
-                  session?.forwardPath?.IntermediatePath?.map((hop: string, i: number) => (
-                    <Hop
-                      className="hop"
-                      key={`hop-f-${i}`}
-                    >
-                      {hop}
-                      {i === 0 && <PingModal address={hop} />}
-                    </Hop>
-                  ))
-                }
+                {session?.forwardPath?.IntermediatePath?.map((hop: string, i: number) => (
+                  <Hop
+                    className="hop"
+                    key={`hop-f-${i}`}
+                  >
+                    {hop}
+                    {i === 0 && <PingModal address={hop} />}
+                  </Hop>
+                ))}
               </>
-            }
+            )}
           </span>
           <br />
           <strong>Return path:</strong>
           <br />
           <span style={{ whiteSpace: 'break-spaces' }}>
-            {
-              JSON.stringify(session.returnPath).includes('Hops') ?
+            {JSON.stringify(session.returnPath).includes('Hops') ? (
               JSON.stringify(session.returnPath)
-              .replace(/{|}|\[|\]|"/g, '')
-              .replace('IntermediatePath:', 'IntermediatePath:\n')
-              .replace(/,/g, ' ')
-              :
+                .replace(/{|}|\[|\]|"/g, '')
+                .replace('IntermediatePath:', 'IntermediatePath:\n')
+                .replace(/,/g, ' ')
+            ) : (
               <>
-                {
-                  session?.returnPath?.IntermediatePath?.map((hop: string, i: number) => (
-                    <Hop
-                      className="hop"
-                      key={`hop-r-${i}`}
-                    >
-                      {hop}
-                      {i === (session?.returnPath?.IntermediatePath?.length ?? 0) - 1 && <PingModal address={hop} />}
-                    </Hop>
-                  ))
-                }
+                {session?.returnPath?.IntermediatePath?.map((hop: string, i: number) => (
+                  <Hop
+                    className="hop"
+                    key={`hop-r-${i}`}
+                  >
+                    {hop}
+                    {i === (session?.returnPath?.IntermediatePath?.length ?? 0) - 1 && <PingModal address={hop} />}
+                  </Hop>
+                ))}
               </>
-            }
+            )}
           </span>
         </>
       ),

--- a/src/pages/node/tickets.tsx
+++ b/src/pages/node/tickets.tsx
@@ -23,15 +23,27 @@ function TicketsPage() {
   const statistics = useAppSelector((store) => store.node.statistics.data);
   const statisticsFetching = useAppSelector((store) => store.node.statistics.isFetching);
   const redeemAllTicketsFetching = useAppSelector((store) => store.node.redeemAllTickets.isFetching);
+  const resettingTicketStatistics = useAppSelector((store) => store.node.resetTicketStatistics.isFetching);
   const redeemAllTicketsErrors = useAppSelector((store) => store.node.redeemAllTickets.error);
   const loginData = useAppSelector((store) => store.auth.loginData);
   const info = useAppSelector((store) => store.node.info.data);
   const ticketPrice = useAppSelector((store) => store.node.ticketPrice.data);
   const minimumNetworkProbability = useAppSelector((store) => store.node.probability.data);
+  const [resettingStats, set_resettingStats] = useState(false);
 
   useEffect(() => {
     handleRefresh();
   }, [loginData, dispatch]);
+
+  useEffect(() => {
+    if (resettingTicketStatistics) {
+      set_resettingStats(true);
+    } else {
+      setTimeout(() => {
+        set_resettingStats(false);
+      }, 2000);
+    }
+  }, [resettingTicketStatistics]);
 
   const handleRefresh = () => {
     if (loginData.apiEndpoint) {
@@ -104,7 +116,7 @@ function TicketsPage() {
                   ticket statistics
                 </span>
               }
-              reloading={redeemAllTicketsFetching}
+              reloading={resettingStats}
               onClick={handleResetTicketsStatistics}
             />
           </>

--- a/src/store/slices/node/actionsAsync.ts
+++ b/src/store/slices/node/actionsAsync.ts
@@ -1148,6 +1148,9 @@ export const createAsyncReducer = (builder: ActionReducerMapBuilder<typeof initi
       const sortedAnnouncedPeers = action.payload?.announced.map((peer) => peer.address).sort();
       state.peers.parsed.connectedSorted = sortedConnectedPeers || [];
       state.peers.parsed.announcedSorted = sortedAnnouncedPeers || [];
+      action.payload?.connected.forEach((peer) => {
+        state.peers.parsed.connected[peer.address] = peer;
+      });
     }
 
     if (!state.peers.alreadyFetched) state.peers.alreadyFetched = true;

--- a/src/store/slices/node/initialState.ts
+++ b/src/store/slices/node/initialState.ts
@@ -162,8 +162,7 @@ type InitialState = {
       connected: {
         //TODO: add ConnectedPeerType to SDK
         [peerId: string]: {
-          peerId: string;
-          peerAddress: string;
+          address: string;
           quality: number;
           multiaddr: string | null;
           heartbeats: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -719,10 +719,10 @@
   resolved "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
-"@hoprnet/hopr-sdk@3.0.3-pr.156-20250915124445":
-  version "3.0.3-pr.156-20250915124445"
-  resolved "https://europe-west3-npm.pkg.dev/hoprassociation/npm/@hoprnet/hopr-sdk/-/@hoprnet/hopr-sdk-3.0.3-pr.156-20250915124445.tgz#f4384a557723d52c9ae504eae67a00b555bf3519"
-  integrity sha512-KcpV6nuWvbXXvKG9ehbBXmSnbosdgGNiR95sRN+UKHsNI3o0coC0IwU37+tkXc3WfM0kwfmz7AmR4B7R60vFNg==
+"@hoprnet/hopr-sdk@3.0.3-pr.156-20250916114518":
+  version "3.0.3-pr.156-20250916114518"
+  resolved "https://europe-west3-npm.pkg.dev/hoprassociation/npm/@hoprnet/hopr-sdk/-/@hoprnet/hopr-sdk-3.0.3-pr.156-20250916114518.tgz#7837d43929d5f721b6fb83fb9a58ec5753fe4449"
+  integrity sha512-r07d0yGBtf9PYyzl+7LQqYRQMFULirIwkuYRAg5As11Zie8wnseoaObmDmR6mV8F5shdD9smCdRWquX6u7fosg==
   dependencies:
     debug "^4.3.4"
     isomorphic-ws "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -719,10 +719,10 @@
   resolved "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
-"@hoprnet/hopr-sdk@3.0.3-pr.156-20250910174548":
-  version "3.0.3-pr.156-20250910174548"
-  resolved "https://europe-west3-npm.pkg.dev/hoprassociation/npm/@hoprnet/hopr-sdk/-/@hoprnet/hopr-sdk-3.0.3-pr.156-20250910174548.tgz#bf87fbf886229decfbde262d2daa0fa637dd6ac0"
-  integrity sha512-akI/j4fJUjx1ltRLfunr0KHaEQRX8KteGxfQnJarlCiKvw0yphR0B27wA4nJWJb/xj+oXfHPdA8ryx6RdCDLPA==
+"@hoprnet/hopr-sdk@3.0.3-pr.156-20250915124445":
+  version "3.0.3-pr.156-20250915124445"
+  resolved "https://europe-west3-npm.pkg.dev/hoprassociation/npm/@hoprnet/hopr-sdk/-/@hoprnet/hopr-sdk-3.0.3-pr.156-20250915124445.tgz#f4384a557723d52c9ae504eae67a00b555bf3519"
+  integrity sha512-KcpV6nuWvbXXvKG9ehbBXmSnbosdgGNiR95sRN+UKHsNI3o0coC0IwU37+tkXc3WfM0kwfmz7AmR4B7R60vFNg==
   dependencies:
     debug "^4.3.4"
     isomorphic-ws "^5.0.0"


### PR DESCRIPTION
Changelog:
 -  RPC provider URL on Node Info gets hidden automatically if a secret is detected. It's possible to mask/unmask the secret using a button next to it
 - OPEN session listener modal got updated with 'Max clients', 'Max surb upstream' and new capabiliteis
 - OPEN session listener modal now will remember the session parameters after closing it, for easier deving and debigging 
 - In the sessions table, a 'ping button' on the first node of the forward path and the last node of the return path is now present to ping/test if the node can see the nodes it should communicate with while using sessions.
 - Fixed last seen column on aliases page
 - Added 'add alias' button in channels table
 - HOPRd SDK updated to support current (2025-09-17 V3 HOPRd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Mask/unmask RPC provider URL on Node Info with visibility toggle; shows masked/invalid/Faulty RPC states.
  - 
  - Expanded session listener UI: new session limits, capability toggles, updated defaults, validation, and layout improvements.
  - Alias creation now works directly by node address (simpler create-alias flow).

- Bug Fixes
  - Icon buttons disabled while reloading to prevent accidental clicks.
  - Ticket statistics reset shows progress, delays briefly on completion, and refreshes stats.

- Chores
  - Updated @hoprnet/hopr-sdk prerelease dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->